### PR TITLE
🦋 Security 기초 설정 🦋

### DIFF
--- a/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
@@ -1,0 +1,40 @@
+package com.thepan.reservationapiserver.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher
+
+@EnableWebSecurity
+@Configuration
+@EnableMethodSecurity
+class SecurityConfig {
+    
+    @Bean
+    fun webSecurityCustomizer(): WebSecurityCustomizer {
+        return WebSecurityCustomizer {
+            it.ignoring()
+                .requestMatchers(AntPathRequestMatcher("/h2-console/**"))
+        }
+    }
+    
+    @Bean
+    fun filterChain(http: HttpSecurity): SecurityFilterChain {
+        http.csrf { it.disable() }
+            .formLogin { it.disable() }
+            .httpBasic { it.disable() }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .authorizeHttpRequests { auth -> // 인증, 인가 설정
+                auth.requestMatchers(
+                    "/api/v1/**",
+                ).permitAll()
+            }
+        
+        return http.build()
+    }
+}


### PR DESCRIPTION
## 🌸 SecurityConfig
- h2 database 접근할 수 있도록 설정

- 일단 개발 초기단계에서 모든 API 에 권한 및 인가 없이 접근할 수 있도록 설정

- csrf 👉 `Rest Api`를 이용한 서버라면, `SESSION` 기반 인증과는 다르게 `stateless`하기 때문에 서버에 인증정보를 보관하지 않음 따라서 비활성화

- formLogin 👉 `JWT Token` 인증을 사용할 것 이므로 비활성화

- httpBasic 👉 기본 인증 로그인을 이용하지 않기때문에 비활성화

- sessionManagement 👉 `JWT Token` 를 사용할 것 이므로 `SESSION` 사용안함