### PR TITLE
🦋JWT Token 인증 기반 작업 - 2️⃣ JWT 인증 로그인 추가 🦋

### DIFF
--- a/src/main/kotlin/com/thepan/reservationapiserver/InitDB.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/InitDB.kt
@@ -49,7 +49,7 @@ class InitDB(
             phoneNumber = "01022696141",
             password = bCryptPasswordEncoder.encode("dudwns@651342"),
             roles = listOf(
-                roleRepository.findByRoleType(RoleType.ROLE_ADMIN) ?: throw RoleNotFoundException()
+                roleRepository.findByRoleType(RoleType.ROLE_MASTER) ?: throw RoleNotFoundException()
             )
         )
         adminMasterList.add(master)

--- a/src/main/kotlin/com/thepan/reservationapiserver/advice/ExceptionAdvice.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/advice/ExceptionAdvice.kt
@@ -1,6 +1,8 @@
 package com.thepan.reservationapiserver.advice
 
 import com.thepan.reservationapiserver.domain.base.ApiResponse
+import com.thepan.reservationapiserver.exception.AccessDeniedException
+import com.thepan.reservationapiserver.exception.AuthenticationEntryPointException
 import com.thepan.reservationapiserver.exception.LoginFailureException
 import com.thepan.reservationapiserver.exception.RoleNotFoundException
 import com.thepan.reservationapiserver.exception.SeatNotFoundException
@@ -59,5 +61,19 @@ class ExceptionAdvice {
     @ResponseStatus(HttpStatus.UNAUTHORIZED) // 401
     fun loginFailureException(e: LoginFailureException): ApiResponse<Unit> {
         return ApiResponse.failure(-1005, "로그인에 실패하였습니다.")
+    }
+    
+    // 📌 인증되지 않은 사용자, 401 응답
+    @ExceptionHandler(AuthenticationEntryPointException::class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    fun authenticationEntryPoint(): ApiResponse<Unit> {
+        return ApiResponse.failure(-1001, "인증되지 않은 사용자입니다.")
+    }
+    
+    // ✅ 인증은 되었으나 권한이 없는 경우, 403 응답
+    @ExceptionHandler(AccessDeniedException::class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    fun accessDeniedException(): ApiResponse<Unit> {
+        return ApiResponse.failure(-1002, "접근 권한이 없습니다.")
     }
 }

--- a/src/main/kotlin/com/thepan/reservationapiserver/advice/ExceptionAdvice.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/advice/ExceptionAdvice.kt
@@ -1,6 +1,7 @@
 package com.thepan.reservationapiserver.advice
 
 import com.thepan.reservationapiserver.domain.base.ApiResponse
+import com.thepan.reservationapiserver.exception.LoginFailureException
 import com.thepan.reservationapiserver.exception.RoleNotFoundException
 import com.thepan.reservationapiserver.exception.SeatNotFoundException
 import mu.KotlinLogging
@@ -52,5 +53,11 @@ class ExceptionAdvice {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     fun roleNotFoundException(): ApiResponse<Unit> {
         return ApiResponse.failure(-1004, "요청한 등급을 찾을 수 없습니다.")
+    }
+    
+    @ExceptionHandler(LoginFailureException::class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED) // 401
+    fun loginFailureException(e: LoginFailureException): ApiResponse<Unit> {
+        return ApiResponse.failure(-1005, "로그인에 실패하였습니다.")
     }
 }

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
@@ -1,5 +1,8 @@
 package com.thepan.reservationapiserver.config
 
+import com.thepan.reservationapiserver.config.jwt.JwtTokenService
+import com.thepan.reservationapiserver.config.security.CustomUserDetailsService
+import com.thepan.reservationapiserver.config.security.JwtTokenAuthenticationFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
@@ -9,12 +12,16 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher
 
 @EnableWebSecurity
 @Configuration
 @EnableMethodSecurity
-class SecurityConfig {
+class SecurityConfig(
+    private val tokenService: JwtTokenService,
+    private val userDetailsService: CustomUserDetailsService
+) {
     
     @Bean
     fun webSecurityCustomizer(): WebSecurityCustomizer {
@@ -35,7 +42,7 @@ class SecurityConfig {
                     "/api/v1/**",
                 ).permitAll()
             }
-        
+            .addFilterBefore(JwtTokenAuthenticationFilter(tokenService, userDetailsService), UsernamePasswordAuthenticationFilter::class.java)
         return http.build()
     }
     

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
@@ -41,6 +41,8 @@ class SecurityConfig(
                 auth.requestMatchers(
                     "/api/v1/**",
                 ).permitAll()
+                    .anyRequest() // 위의 요청을 제외한 나머지 요청
+                    .authenticated() // 별도의 인가는 필요하지 않지만 인증이 접근할 수 있음
             }
             .addFilterBefore(JwtTokenAuthenticationFilter(tokenService, userDetailsService), UsernamePasswordAuthenticationFilter::class.java)
         return http.build()

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
@@ -1,10 +1,13 @@
 package com.thepan.reservationapiserver.config
 
 import com.thepan.reservationapiserver.config.jwt.JwtTokenService
+import com.thepan.reservationapiserver.config.security.CustomAccessDeniedHandler
+import com.thepan.reservationapiserver.config.security.CustomAuthenticationEntryPoint
 import com.thepan.reservationapiserver.config.security.CustomUserDetailsService
 import com.thepan.reservationapiserver.config.security.JwtTokenAuthenticationFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
@@ -28,6 +31,7 @@ class SecurityConfig(
         return WebSecurityCustomizer {
             it.ignoring()
                 .requestMatchers(AntPathRequestMatcher("/h2-console/**"))
+                .requestMatchers(AntPathRequestMatcher("/exception/**"))
         }
     }
     
@@ -39,10 +43,17 @@ class SecurityConfig(
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests { auth -> // 인증, 인가 설정
                 auth.requestMatchers(
-                    "/api/v1/**",
+                    "/api/v1/sign/**",
                 ).permitAll()
+                    .requestMatchers(HttpMethod.POST, "/api/v1/reservation").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/v1/reservation").hasRole("MASTER")
+                    .requestMatchers(HttpMethod.GET, "/api/v1/reservation/status").hasRole("MASTER")
                     .anyRequest() // 위의 요청을 제외한 나머지 요청
                     .authenticated() // 별도의 인가는 필요하지 않지만 인증이 접근할 수 있음
+            }
+            .exceptionHandling {
+                it.accessDeniedHandler(CustomAccessDeniedHandler())
+                it.authenticationEntryPoint(CustomAuthenticationEntryPoint())
             }
             .addFilterBefore(JwtTokenAuthenticationFilter(tokenService, userDetailsService), UsernamePasswordAuthenticationFilter::class.java)
         return http.build()

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/jwt/JwtTokenHelper.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/jwt/JwtTokenHelper.kt
@@ -55,6 +55,7 @@ class JwtTokenHelper {
     private fun removeBearer(token: String): String = token.substring(TYPE.length)
     
     companion object {
-        private const val TYPE = "Bearer "
+        const val TYPE = "Bearer "
+        const val HEADER_AUTHORIZATION = "Authorization"
     }
 }

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/jwt/JwtTokenService.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/jwt/JwtTokenService.kt
@@ -3,7 +3,10 @@ package com.thepan.reservationapiserver.config.jwt
 import org.springframework.stereotype.Service
 
 @Service
-class JwtTokenService(private val jwtTokenHelper: JwtTokenHelper, private val jwtTokenProperties: JwtTokenProperties) {
+class JwtTokenService(
+    private val jwtTokenHelper: JwtTokenHelper,
+    private val jwtTokenProperties: JwtTokenProperties
+) {
     
     fun createAccessToken(subject: String): String = with(jwtTokenProperties) {
         jwtTokenHelper.createToken(issuer, subject, secretKey, expireTime)

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/security/CustomAccessDeniedHandler.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/security/CustomAccessDeniedHandler.kt
@@ -1,0 +1,21 @@
+package com.thepan.reservationapiserver.config.security
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.web.access.AccessDeniedHandler
+
+/**
+ * @author choi young-jun
+ *
+ * 📌 인증된 사용자가 "권한 부족" 등의 사유로 인해 접근이 거부되었을 때 작동할 핸들러
+ * - Controller 계층에 도달하기 전에 수행되기 때문에 ExceptionAdvice 에서 이 예외를 잡아낼 수 없음
+ * -  예외 사항을 다루는 방식의 일관성을 위해 /exception/access-denied 로 요청을 보내서
+ *    Controller 안에서 throw 를 던져 ExceptionAdvice 에서 처리될 수 있도록 했음
+ */
+class CustomAccessDeniedHandler : AccessDeniedHandler {
+    // 인증된 사용자가 자원에 접근할 권한이 없을 때 호출
+    override fun handle(request: HttpServletRequest?, response: HttpServletResponse?, accessDeniedException: AccessDeniedException?) {
+        response?.sendRedirect("/exception/access-denied")
+    }
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/security/CustomAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/security/CustomAuthenticationEntryPoint.kt
@@ -1,0 +1,21 @@
+package com.thepan.reservationapiserver.config.security
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+
+/**
+ * @author choi young-jun
+ *
+ * 📌 인증되지 않은 사용자의 접근이 거부되었을 때 작동할 핸들러 (JWT Token 이 없는 경우)
+ * - Controller 계층에 도달하기 전에 수행되기 때문에 ExceptionAdvice 에서 이 예외를 잡아낼 수 없음
+ * -  예외 사항을 다루는 방식의 일관성을 위해 /exception/entry-point 로 요청을 보내서
+ *    Controller 안에서 throw 를 던져 ExceptionAdvice 에서 처리될 수 있도록 했음
+ */
+class CustomAuthenticationEntryPoint : AuthenticationEntryPoint {
+    // 인증이 필요한 자원에 대한 요청이 들어올 때, 해당 요청이 인증되지 않은 상태인 경우에 호출
+    override fun commence(request: HttpServletRequest?, response: HttpServletResponse?, authException: AuthenticationException?) {
+        response?.sendRedirect("/exception/entry-point")
+    }
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/security/CustomAuthenticationToken.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/security/CustomAuthenticationToken.kt
@@ -1,0 +1,20 @@
+package com.thepan.reservationapiserver.config.security
+
+import org.springframework.security.authentication.AbstractAuthenticationToken
+import org.springframework.security.core.GrantedAuthority
+
+class CustomAuthenticationToken(
+    private val principal: CustomUserDetails,
+    authorities: Collection<GrantedAuthority>
+) : AbstractAuthenticationToken(authorities) {
+    
+    init {
+        super.setAuthenticated(true)
+    }
+    
+    override fun getCredentials(): Any {
+        throw UnsupportedOperationException()
+    }
+    
+    override fun getPrincipal(): CustomUserDetails = principal
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/security/CustomUserDetails.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/security/CustomUserDetails.kt
@@ -1,0 +1,49 @@
+package com.thepan.reservationapiserver.config.security
+
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.userdetails.UserDetails
+import java.util.stream.Collectors
+
+class CustomUserDetails(
+    val userId: String,
+    private val password: String,
+    private val authorities: Set<GrantedAuthority>
+) : UserDetails {
+    override fun getAuthorities(): MutableCollection<out GrantedAuthority> {
+        return authorities.stream().collect(Collectors.toSet())
+    }
+    
+    // 📌 사용자의 비밀번호 반환(비밀번호는 암호화해서 저장해야함)
+    override fun getPassword(): String = password
+    
+    // 📌 사용자 id 를 반환(unique)
+    override fun getUsername(): String = userId
+    
+    /**
+     * 📌 계정이 만료 여부 반환
+     * - true : 만료 X
+     * - false : 만료 O
+     */
+    override fun isAccountNonExpired(): Boolean = true
+    
+    /**
+     * 📌 계정이 잠금되어있는지 여부 반환
+     * - true : 잠금 X
+     * - false : 만료 O
+     */
+    override fun isAccountNonLocked(): Boolean = true
+    
+    /**
+     * 📌 패스워드 만료 여부 반환
+     * - true : 만료 X,
+     * - false : 만료 O
+     */
+    override fun isCredentialsNonExpired(): Boolean = true
+    
+    /**
+     * 📌 계정 사용 가능 여부 반환
+     * - true : 사용 가능,
+     * - false : 사용 불가
+     */
+    override fun isEnabled(): Boolean = true
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/security/CustomUserDetailsService.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/security/CustomUserDetailsService.kt
@@ -1,0 +1,30 @@
+package com.thepan.reservationapiserver.config.security
+
+import com.thepan.reservationapiserver.domain.mapper.toCustomUserDetails
+import com.thepan.reservationapiserver.domain.member.repository.MemberRepository
+import mu.KotlinLogging
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * @author choi young-jun
+ *
+ * 📌 Spring Security Context 에 인증된 사용자 정보를 저장
+ * - 이렇게하면 Security 에서 인증된 유저의 정보를 가져올 수 있음
+ */
+@Component
+@Transactional(readOnly = true)
+class CustomUserDetailsService(
+    private val memberRepository: MemberRepository
+) : UserDetailsService {
+    private val log = KotlinLogging.logger {}
+    
+    override fun loadUserByUsername(username: String): CustomUserDetails {
+        log.info("🦋 CustomUserDetailService > loadUserByUsername > username 👉 $username")
+        
+        return memberRepository.findWithRolesById(username.toLong())?.toCustomUserDetails()
+            ?: throw UsernameNotFoundException("🦋$username Can Not Found 🦋")
+    }
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/security/JwtTokenAuthenticationFilter.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/security/JwtTokenAuthenticationFilter.kt
@@ -24,17 +24,17 @@ class JwtTokenAuthenticationFilter(
     private val log = KotlinLogging.logger {}
     
     override fun doFilterInternal(request: HttpServletRequest, response: HttpServletResponse, filterChain: FilterChain) {
-        val token = request.getHeader(HEADER_AUTHORIZATION).takeIf {
+        val token = request.getHeader(HEADER_AUTHORIZATION)?.takeIf {
             it.isNotBlank() && it.startsWith(TYPE)
         }
-        
+    
         token?.let {
             if (tokenService.validateAccessToken(it)) {
                 log.info("🌸🌸🌸 인증된 Token 👉 $it")
                 setAccessAuthentication(token)
             }
         }
-        
+    
         filterChain.doFilter(request, response)
     }
     

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/security/JwtTokenAuthenticationFilter.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/security/JwtTokenAuthenticationFilter.kt
@@ -1,0 +1,46 @@
+package com.thepan.reservationapiserver.config.security
+
+import com.thepan.reservationapiserver.config.jwt.JwtTokenHelper.Companion.HEADER_AUTHORIZATION
+import com.thepan.reservationapiserver.config.jwt.JwtTokenHelper.Companion.TYPE
+import com.thepan.reservationapiserver.config.jwt.JwtTokenService
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import mu.KotlinLogging
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.filter.OncePerRequestFilter
+
+/**
+ * @author choi young-jun
+ *
+ * 📌 OncePerRequestFilter
+ * - request 당 한 번만 실행되도록 보장 (동일한 request 에 대한 중복 실행을 방지)
+ * - 인증이나 권한 부여에 관한 작업 수행
+ */
+class JwtTokenAuthenticationFilter(
+    private val tokenService: JwtTokenService,
+    private val userDetailsService: CustomUserDetailsService
+) : OncePerRequestFilter() {
+    private val log = KotlinLogging.logger {}
+    
+    override fun doFilterInternal(request: HttpServletRequest, response: HttpServletResponse, filterChain: FilterChain) {
+        val token = request.getHeader(HEADER_AUTHORIZATION).takeIf {
+            it.isNotBlank() && it.startsWith(TYPE)
+        }
+        
+        token?.let {
+            if (tokenService.validateAccessToken(it)) {
+                log.info("🌸🌸🌸 인증된 Token 👉 $it")
+                setAccessAuthentication(token)
+            }
+        }
+        
+        filterChain.doFilter(request, response)
+    }
+    
+    private fun setAccessAuthentication(token: String) {
+        val memberId = tokenService.extractAccessTokenSubject(token)
+        val userDetails: CustomUserDetails = userDetailsService.loadUserByUsername(memberId)
+        SecurityContextHolder.getContext().authentication = CustomAuthenticationToken(userDetails, userDetails.authorities)
+    }
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/controller/ExceptionApiController.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/controller/ExceptionApiController.kt
@@ -1,0 +1,19 @@
+package com.thepan.reservationapiserver.controller
+
+import com.thepan.reservationapiserver.exception.AccessDeniedException
+import com.thepan.reservationapiserver.exception.AuthenticationEntryPointException
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ExceptionApiController {
+    @GetMapping("/exception/entry-point")
+    fun entryPoint() {
+        throw AuthenticationEntryPointException()
+    }
+    
+    @GetMapping("/exception/access-denied")
+    fun accessDenied() {
+        throw AccessDeniedException()
+    }
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/controller/SignApiController.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/controller/SignApiController.kt
@@ -1,0 +1,23 @@
+package com.thepan.reservationapiserver.controller
+
+import com.thepan.reservationapiserver.domain.base.ApiResponse
+import com.thepan.reservationapiserver.domain.sign.dto.SignInRequest
+import com.thepan.reservationapiserver.domain.sign.dto.SignInResponse
+import com.thepan.reservationapiserver.domain.sign.service.SignService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/sign")
+class SignApiController(
+    private val signService: SignService
+) {
+    @PostMapping("/signIn")
+    @ResponseStatus(HttpStatus.OK)
+    fun signIn(
+        @Valid
+        @RequestBody
+        request: SignInRequest
+    ): ApiResponse<SignInResponse> = ApiResponse.success(signService.signIn(request))
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/mapper/OjbectMapper.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/mapper/OjbectMapper.kt
@@ -1,11 +1,17 @@
 package com.thepan.reservationapiserver.domain.mapper
 
+import com.thepan.reservationapiserver.config.security.CustomUserDetails
+import com.thepan.reservationapiserver.domain.member.entity.Member
+import com.thepan.reservationapiserver.domain.member.entity.MemberRole
 import com.thepan.reservationapiserver.domain.reservation.dto.ReservationAllResponse
 import com.thepan.reservationapiserver.domain.reservation.dto.ReservationCreateRequest
 import com.thepan.reservationapiserver.domain.reservation.entity.Reservation
 import com.thepan.reservationapiserver.domain.seat.entity.Seat
 import com.thepan.reservationapiserver.domain.seat.entity.SeatType
 import com.thepan.reservationapiserver.exception.SeatNotFoundException
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import java.util.stream.Collectors
 
 fun ReservationCreateRequest.toEntity(seats: List<Seat>): Reservation = Reservation(
     name = this.name,
@@ -40,3 +46,18 @@ fun List<String>.toSeatTypeList(): List<SeatType> {
         throw SeatNotFoundException()
     }
 }
+
+fun Member.toCustomUserDetails() = CustomUserDetails(
+    userId = id.toString(),
+    password = password,
+    authorities = roles.toAuthorities()
+)
+
+private fun MutableSet<MemberRole>.toAuthorities(): Set<GrantedAuthority> = stream().map {
+    it.role
+}.map {
+    it.roleType
+}.map {
+    print("🦋 CustomUserDetails roleType 👉 $it \n")
+    it.toString()
+}.map(::SimpleGrantedAuthority).collect(Collectors.toSet())

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/dto/SignInRequest.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/dto/SignInRequest.kt
@@ -1,0 +1,12 @@
+package com.thepan.reservationapiserver.domain.sign.dto
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+
+data class SignInRequest(
+    @field: Email(message = "이메일 형식을 맞춰주세요.")
+    @field: NotBlank(message = "이메일을 입력해주세요.")
+    val email: String,
+    @field: NotBlank(message = "비밀번호를 입력해주세요.")
+    val password: String
+)

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/dto/SignInResponse.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/dto/SignInResponse.kt
@@ -1,0 +1,6 @@
+package com.thepan.reservationapiserver.domain.sign.dto
+
+data class SignInResponse(
+    val token: String,
+    val refreshToken: String
+)

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/service/SignService.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/service/SignService.kt
@@ -1,0 +1,34 @@
+package com.thepan.reservationapiserver.domain.sign.service
+
+import com.thepan.reservationapiserver.config.jwt.JwtTokenService
+import com.thepan.reservationapiserver.domain.member.entity.Member
+import com.thepan.reservationapiserver.domain.member.repository.MemberRepository
+import com.thepan.reservationapiserver.domain.sign.dto.SignInRequest
+import com.thepan.reservationapiserver.domain.sign.dto.SignInResponse
+import com.thepan.reservationapiserver.exception.LoginFailureException
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class SignService(
+    private val memberRepository: MemberRepository,
+    private val bCryptPasswordEncoder: BCryptPasswordEncoder,
+    private val jwtTokenService: JwtTokenService
+) {
+    
+    @Transactional(readOnly = true)
+    fun signIn(request: SignInRequest): SignInResponse {
+        val member = memberRepository.findByEmail(request.email) ?: throw LoginFailureException()
+        validatePassword(request.password, member)
+        
+        val token = jwtTokenService.createAccessToken(member.id.toString())
+        val refreshToken = jwtTokenService.createRefreshToken(member.id.toString())
+        return SignInResponse(token, refreshToken)
+    }
+    
+    private fun validatePassword(password: String, member: Member) {
+        if (!bCryptPasswordEncoder.matches(password, member.password))
+            throw LoginFailureException()
+    }
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/exception/AccessDeniedException.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/exception/AccessDeniedException.kt
@@ -1,0 +1,3 @@
+package com.thepan.reservationapiserver.exception
+
+class AccessDeniedException : RuntimeException()

--- a/src/main/kotlin/com/thepan/reservationapiserver/exception/AuthenticationEntryPointException.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/exception/AuthenticationEntryPointException.kt
@@ -1,0 +1,3 @@
+package com.thepan.reservationapiserver.exception
+
+class AuthenticationEntryPointException : RuntimeException()

--- a/src/main/kotlin/com/thepan/reservationapiserver/exception/LoginFailureException.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/exception/LoginFailureException.kt
@@ -1,0 +1,3 @@
+package com.thepan.reservationapiserver.exception
+
+class LoginFailureException : RuntimeException()


### PR DESCRIPTION
# 🦋 JWT 인증 로그인
## 🌸 Security 설정
- CustomUserDetails, CustomUserDetailsService, CustomAuthenticationToken, JwtTokenAuthenticationFilter 생성

### 🌹 CustomUserDetails, CustomUserDetailsService
- Spring Security Context 에 **_인증된_** 사용자 정보를 저장
- Security 에서 인증된 유저의 정보를 가져올 수 있음
- memberId 를 통해 Spring Security Context 에 UserDetails 를 저장함

### 🌹 CustomAuthenticationToken
- 인증이 끝나고 `SecurityContextHolder.getContext()`에 등록될 Authentication 객체

### 🌹 JwtTokenAuthenticationFilter
- `OncePerRequestFilter` 를 상속받아 사용
  > - request 당 한 번만 실행되도록 보장
  > - 즉, 동일한 request 에 대한 중복 실행을 방지

- 인증이나 권한 부여에 관한 작업을 수행
  > **_참고_**
  > -
  > ※ 로직
  > 1. request 요청이 들어오면 해당 request 에서 header 를 가져옴
  > 2. header 에 `Authorization` 가 있고 `Bearer ` 로 시작한다면 Token 이 있는 것으로 판별
  > 3. Token 이 존재한다면 정상적인 Token 인지 JwtTokenService 를 통해 유효성 검증 실시
  > 4. 정상적인 Token 이라면 SecurityContextHolder.getContext() 에 UserDetails 등록

### 🌹 SecurityConfig
- 위에서 정의한 JwtTokenAuthenticationFilter 를 addFilterBefore 를 통해 등록#7 

## 🌸 로그인 API 생성
- /api/v1/sign/signIn 를 호출하여 로그인을 할 수 있도록 기능 추가
- 로그인 성공 👉 응답값에 AccessToken 과 RefreshToken 을 넘겨줌
- 로그인 실패 👉 LoginFailureException 를 throw 하여 이메일이 잘못되었든 비밀번호가 잘못되었든 **_일관되게_** "로그인에 실패하였습니다." 메시지를 던져줌