### PR TITLE
🦋JWT Token 인증 기반 작업 - 3️⃣ 인증 / 인가 권한 Handling 🦋

### DIFF
--- a/src/main/kotlin/com/thepan/reservationapiserver/InitDB.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/InitDB.kt
@@ -49,7 +49,7 @@ class InitDB(
             phoneNumber = "01022696141",
             password = bCryptPasswordEncoder.encode("dudwns@651342"),
             roles = listOf(
-                roleRepository.findByRoleType(RoleType.ROLE_ADMIN) ?: throw RoleNotFoundException()
+                roleRepository.findByRoleType(RoleType.ROLE_MASTER) ?: throw RoleNotFoundException()
             )
         )
         adminMasterList.add(master)

--- a/src/main/kotlin/com/thepan/reservationapiserver/advice/ExceptionAdvice.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/advice/ExceptionAdvice.kt
@@ -1,6 +1,8 @@
 package com.thepan.reservationapiserver.advice
 
 import com.thepan.reservationapiserver.domain.base.ApiResponse
+import com.thepan.reservationapiserver.exception.AccessDeniedException
+import com.thepan.reservationapiserver.exception.AuthenticationEntryPointException
 import com.thepan.reservationapiserver.exception.LoginFailureException
 import com.thepan.reservationapiserver.exception.RoleNotFoundException
 import com.thepan.reservationapiserver.exception.SeatNotFoundException
@@ -59,5 +61,19 @@ class ExceptionAdvice {
     @ResponseStatus(HttpStatus.UNAUTHORIZED) // 401
     fun loginFailureException(e: LoginFailureException): ApiResponse<Unit> {
         return ApiResponse.failure(-1005, "로그인에 실패하였습니다.")
+    }
+    
+    // 📌 인증되지 않은 사용자, 401 응답
+    @ExceptionHandler(AuthenticationEntryPointException::class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    fun authenticationEntryPoint(): ApiResponse<Unit> {
+        return ApiResponse.failure(-1001, "인증되지 않은 사용자입니다.")
+    }
+    
+    // ✅ 인증은 되었으나 권한이 없는 경우, 403 응답
+    @ExceptionHandler(AccessDeniedException::class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    fun accessDeniedException(): ApiResponse<Unit> {
+        return ApiResponse.failure(-1002, "접근 권한이 없습니다.")
     }
 }

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
@@ -1,10 +1,13 @@
 package com.thepan.reservationapiserver.config
 
 import com.thepan.reservationapiserver.config.jwt.JwtTokenService
+import com.thepan.reservationapiserver.config.security.CustomAccessDeniedHandler
+import com.thepan.reservationapiserver.config.security.CustomAuthenticationEntryPoint
 import com.thepan.reservationapiserver.config.security.CustomUserDetailsService
 import com.thepan.reservationapiserver.config.security.JwtTokenAuthenticationFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
@@ -28,6 +31,7 @@ class SecurityConfig(
         return WebSecurityCustomizer {
             it.ignoring()
                 .requestMatchers(AntPathRequestMatcher("/h2-console/**"))
+                .requestMatchers(AntPathRequestMatcher("/exception/**"))
         }
     }
     
@@ -39,10 +43,17 @@ class SecurityConfig(
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests { auth -> // 인증, 인가 설정
                 auth.requestMatchers(
-                    "/api/v1/**",
+                    "/api/v1/sign/**",
                 ).permitAll()
+                    .requestMatchers(HttpMethod.POST, "/api/v1/reservation").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/v1/reservation").hasRole("MASTER")
+                    .requestMatchers(HttpMethod.GET, "/api/v1/reservation/status").hasRole("MASTER")
                     .anyRequest() // 위의 요청을 제외한 나머지 요청
                     .authenticated() // 별도의 인가는 필요하지 않지만 인증이 접근할 수 있음
+            }
+            .exceptionHandling {
+                it.accessDeniedHandler(CustomAccessDeniedHandler())
+                it.authenticationEntryPoint(CustomAuthenticationEntryPoint())
             }
             .addFilterBefore(JwtTokenAuthenticationFilter(tokenService, userDetailsService), UsernamePasswordAuthenticationFilter::class.java)
         return http.build()

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/security/CustomAccessDeniedHandler.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/security/CustomAccessDeniedHandler.kt
@@ -1,0 +1,21 @@
+package com.thepan.reservationapiserver.config.security
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.web.access.AccessDeniedHandler
+
+/**
+ * @author choi young-jun
+ *
+ * 📌 인증된 사용자가 "권한 부족" 등의 사유로 인해 접근이 거부되었을 때 작동할 핸들러
+ * - Controller 계층에 도달하기 전에 수행되기 때문에 ExceptionAdvice 에서 이 예외를 잡아낼 수 없음
+ * -  예외 사항을 다루는 방식의 일관성을 위해 /exception/access-denied 로 요청을 보내서
+ *    Controller 안에서 throw 를 던져 ExceptionAdvice 에서 처리될 수 있도록 했음
+ */
+class CustomAccessDeniedHandler : AccessDeniedHandler {
+    // 인증된 사용자가 자원에 접근할 권한이 없을 때 호출
+    override fun handle(request: HttpServletRequest?, response: HttpServletResponse?, accessDeniedException: AccessDeniedException?) {
+        response?.sendRedirect("/exception/access-denied")
+    }
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/security/CustomAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/security/CustomAuthenticationEntryPoint.kt
@@ -1,0 +1,21 @@
+package com.thepan.reservationapiserver.config.security
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+
+/**
+ * @author choi young-jun
+ *
+ * 📌 인증되지 않은 사용자의 접근이 거부되었을 때 작동할 핸들러 (JWT Token 이 없는 경우)
+ * - Controller 계층에 도달하기 전에 수행되기 때문에 ExceptionAdvice 에서 이 예외를 잡아낼 수 없음
+ * -  예외 사항을 다루는 방식의 일관성을 위해 /exception/entry-point 로 요청을 보내서
+ *    Controller 안에서 throw 를 던져 ExceptionAdvice 에서 처리될 수 있도록 했음
+ */
+class CustomAuthenticationEntryPoint : AuthenticationEntryPoint {
+    // 인증이 필요한 자원에 대한 요청이 들어올 때, 해당 요청이 인증되지 않은 상태인 경우에 호출
+    override fun commence(request: HttpServletRequest?, response: HttpServletResponse?, authException: AuthenticationException?) {
+        response?.sendRedirect("/exception/entry-point")
+    }
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/controller/ExceptionApiController.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/controller/ExceptionApiController.kt
@@ -1,0 +1,19 @@
+package com.thepan.reservationapiserver.controller
+
+import com.thepan.reservationapiserver.exception.AccessDeniedException
+import com.thepan.reservationapiserver.exception.AuthenticationEntryPointException
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ExceptionApiController {
+    @GetMapping("/exception/entry-point")
+    fun entryPoint() {
+        throw AuthenticationEntryPointException()
+    }
+    
+    @GetMapping("/exception/access-denied")
+    fun accessDenied() {
+        throw AccessDeniedException()
+    }
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/exception/AccessDeniedException.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/exception/AccessDeniedException.kt
@@ -1,0 +1,3 @@
+package com.thepan.reservationapiserver.exception
+
+class AccessDeniedException : RuntimeException()

--- a/src/main/kotlin/com/thepan/reservationapiserver/exception/AuthenticationEntryPointException.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/exception/AuthenticationEntryPointException.kt
@@ -1,0 +1,3 @@
+package com.thepan.reservationapiserver.exception
+
+class AuthenticationEntryPointException : RuntimeException()


### PR DESCRIPTION
## 🌸 인증 / 인가 권한 Handling
- 비인증/인증 API 구분 작업 완료
- 인증은 되어있으나 인가가 필요한 경우 구분 완료

### 🌹 비인증/인증 API 구분
- 비인증 API 👉 /api/v1/sign/**, POST /api/v1/reservation
- 인증 API 👉 GET /api/v1/reservation, GET /api/v1/reservation/status

### 🌹 인증 + 인가 API 구분
- GET /api/v1/reservation, GET /api/v1/reservation/status 👉 이 API 들은 MASTER 권한을 갖는 유저만 접근이 가능하도록 설정

### 🌹 Token 이 없는 경우 Handling (CustomAuthenticationEntryPoint)
- `AuthenticationEntryPoint` 를 구현하여 인증되지 않은 사용자의 접근이 거부되었을 때 작동할 핸들러를 지정
  > **_참고_**
  > -
  > ⚠️ 주의
  > - AuthenticationEntryPoint 는 Controller 계층에 도달하기 전에 수행되기 때문에 ExceptionAdvice 에서 이 예외를 잡아낼 수 없음
  > - 예외 사항을 다루는 방식의 일관성을 위해 /exception/entry-point 로 요청을 보내서 Controller 안에서 throw 를 던져 ExceptionAdvice 에서 처리될 수 있도록 처리

### 🌹 인증은 되었으나 권한이 없는 경우 Handling (CustomAccessDeniedHandler)
- `AccessDeniedHandler` 를 구현하여 인증된 사용자가 **_권한 부족_** 등의 사유로 인해 접근이 거부되었을 때 작동할 핸들러를 지정
  > **_참고_**
  > -
  > ⚠️ 주의
  > - AccessDeniedHandler 또한 Controller 계층에 도달하기 전에 수행되기 때문에 ExceptionAdvice 에서 이 예외를 잡아낼 수 없음
  > - 예외 사항을 다루는 방식의 일관성을 위해 /exception/access-denied 로 요청을 보내서 Controller 안에서 throw 를 던져 ExceptionAdvice 에서 처리될 수 있도록 처리