### PR TITLE
🦋 전체 좌석 이름을 가져오는 API 추가 🦋

### DIFF
--- a/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
@@ -44,6 +44,7 @@ class SecurityConfig(
             .authorizeHttpRequests { auth -> // 인증, 인가 설정
                 auth.requestMatchers(
                     "/api/v1/sign/**",
+                    "/api/v1/seats/**"
                 ).permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/v1/reservation").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/v1/reservation").hasRole("MASTER")

--- a/src/main/kotlin/com/thepan/reservationapiserver/controller/SeatApiController.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/controller/SeatApiController.kt
@@ -1,0 +1,21 @@
+package com.thepan.reservationapiserver.controller
+
+import com.thepan.reservationapiserver.domain.base.ApiResponse
+import com.thepan.reservationapiserver.domain.seat.entity.SeatType
+import com.thepan.reservationapiserver.domain.seat.service.SeatService
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1")
+class SeatApiController(
+    private val seatService: SeatService
+) {
+    
+    @GetMapping("/seats")
+    @ResponseStatus(HttpStatus.OK)
+    fun readAll(): ApiResponse<List<SeatType>> = ApiResponse.success(seatService.readAll())
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/seat/service/SeatService.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/seat/service/SeatService.kt
@@ -1,0 +1,19 @@
+package com.thepan.reservationapiserver.domain.seat.service
+
+import com.thepan.reservationapiserver.domain.seat.entity.SeatType
+import com.thepan.reservationapiserver.domain.seat.repository.SeatRepository
+import com.thepan.reservationapiserver.exception.SeatNotFoundException
+import org.springframework.stereotype.Service
+
+@Service
+class SeatService(
+    private val seatRepository: SeatRepository
+) {
+    
+    fun readAll(): List<SeatType> {
+        val seatAllList = seatRepository.findAll()
+        if (seatAllList.isEmpty()) throw SeatNotFoundException()
+        
+        return seatAllList.map { it.seatType }
+    }
+}


### PR DESCRIPTION
## 🌸 전체 좌석 이름을 가져오는 API 추가
- endPoint 👉 GET `/api/v1/seats`
- Spring 시작 시 data.sql 로 저장하는 Seat Entity 전체 좌석 이름을 가져오는 API 추가

### 🌹 Security 설정
- 해당 API는 **_인증/인가_** 를 거치지않고 모든 사용자가 사용할 수 있음