### PR TITLE
🦋 해당 날짜에 남은 좌석 List를 가져오는 API 추가 🦋

### DIFF
--- a/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
@@ -44,7 +44,8 @@ class SecurityConfig(
             .authorizeHttpRequests { auth -> // 인증, 인가 설정
                 auth.requestMatchers(
                     "/api/v1/sign/**",
-                    "/api/v1/seats/**"
+                    "/api/v1/seats/**",
+                    "/api/v1/reservation/seats"
                 ).permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/v1/reservation").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/v1/reservation").hasRole("MASTER")

--- a/src/main/kotlin/com/thepan/reservationapiserver/controller/ReservationApiController.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/controller/ReservationApiController.kt
@@ -4,7 +4,9 @@ import com.thepan.reservationapiserver.domain.base.ApiResponse
 import com.thepan.reservationapiserver.domain.reservation.ReservationService
 import com.thepan.reservationapiserver.domain.reservation.dto.ReservationAllResponse
 import com.thepan.reservationapiserver.domain.reservation.dto.ReservationCreateRequest
+import com.thepan.reservationapiserver.domain.reservation.dto.ReservationSeatListRequest
 import com.thepan.reservationapiserver.domain.reservation.dto.ReservationStatusCondition
+import com.thepan.reservationapiserver.domain.seat.entity.SeatType
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
@@ -39,4 +41,11 @@ class ReservationApiController(
         condition: ReservationStatusCondition
     ): ApiResponse<List<ReservationAllResponse>> =
         ApiResponse.success(reservationService.getReservationStatus(condition))
+    
+    @GetMapping("/reservation/seats")
+    @ResponseStatus(HttpStatus.OK)
+    fun readReservedSeatList(
+        @Valid
+        request: ReservationSeatListRequest
+    ): ApiResponse<List<SeatType>> = ApiResponse.success(reservationService.getTargetReservationSeatList(request))
 }

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/mapper/OjbectMapper.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/mapper/OjbectMapper.kt
@@ -90,3 +90,9 @@ private fun List<RoleType>.toRoleType(): RoleType =
         
         else -> RoleType.ROLE_STOP
     }
+
+fun List<Reservation>.toSeatList(): List<Seat> = flatMap {
+    it.seat
+}.map {
+    it.seat
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/ReservationService.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/ReservationService.kt
@@ -85,6 +85,11 @@ class ReservationService(
         return seatList
     }
     
+    /**
+     * 📌 중복된 좌석 체크
+     * - 해당 날짜로 조회해서 예약 정보가 없으면 👉 좌석이 모두 있다는 의미, 더 이상 밑에 로직 탈 필요없이 return 처리
+     * - 중복된 좌석이 있으면 DuplicateConferenceSeatException 발생
+     */
     private fun checkIsDuplicateSeat(request: ReservationCreateRequest) {
         val selectedSeatList = checkIsValidSeatName(request)
     

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/dto/ReservationSeatListRequest.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/dto/ReservationSeatListRequest.kt
@@ -1,0 +1,10 @@
+package com.thepan.reservationapiserver.domain.reservation.dto
+
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDateTime
+
+data class ReservationSeatListRequest(
+    @field:NotNull
+    val timeType: String,
+    val reservationDateTime: LocalDateTime,
+)

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/repository/ReservationRepository.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/repository/ReservationRepository.kt
@@ -29,7 +29,10 @@ interface ReservationRepository : JpaRepository<Reservation, Long> {
         @Param("reservationDateTime") reservationDateTime: LocalDateTime
     ): Reservation?
     
-    // 📌 좌석 중복 체크에 사용될 것 임
+    /**
+     * 📌 지정된 날짜에 예약된 정보 List 가져오기
+     * - 좌석 중복 체크에 사용될 것 임
+     */
     @Query("SELECT r FROM Reservation r WHERE r.timeType = :timeType AND r.reservationDateTime = :reservationDateTime")
     fun findByTimeTypeAndDateTime(
         @Param("timeType") timeType: TimeType,


### PR DESCRIPTION
## 🌸 해당 날짜에 남은 좌석 List를 가져오는 API 추가
- endpoint 👉 `/api/v1/reservation/seat`

  > **_참고_**
  > -
  > ※ 로직
  > 1. 전체 Seat List 를 가져옴
  > 2. QueryParam 으로 넘어오는 조건에 따라 조회된 해당 날짜의 예약 정보를 List 를 가져옴
  > 3. 2번이 비어있으면 예약을 한 사람이 없기에 좌석 전체 List를 반환
  > 4. 2번이 비어있지 않으면 2번을 `map()`을 통해 좌석 List로 변경
  > 5. 좌석 전체 List에서 예약된 좌석 List(4번)을 제외한 나머지 즉, **_남아있는 좌석만 파싱_** 하여 return

### 🌹 Security 설정
- 해당 날짜에 남은 좌석 List 를 가져오는 API는 비회원이 예약할때도 사용하므로 **_인증/인가_** 를 거치지 않고 누구나 다 접근할 수 있도록 설정