### PR TITLE
🦋 Redis 를 이용한 JWT 로그아웃 기능 추가 🦋

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,9 @@ dependencies {
     // @ConfigurationProperties 사용
     kapt("org.springframework.boot:spring-boot-configuration-processor")
     
+    // Redis 추가
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    
     runtimeOnly("com.h2database:h2")
     
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/RedisRepositoryConfig.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/RedisRepositoryConfig.kt
@@ -1,0 +1,41 @@
+package com.thepan.reservationapiserver.config
+
+import mu.KotlinLogging
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories
+import org.springframework.data.redis.serializer.StringRedisSerializer
+
+
+@Configuration
+@EnableRedisRepositories
+class RedisRepositoryConfig(
+    private val redisProperties: RedisProperties,
+) {
+    
+    /**
+     * 📌 lettuce
+     * - RedisProperties 로 application.yml 에 저장한 host, post를 가지고 와서 연결
+     */
+    @Bean
+    fun redisConnectionFactory(): RedisConnectionFactory =
+        LettuceConnectionFactory(redisProperties.host, redisProperties.port)
+    
+    
+    // setKeySerializer, setValueSerializer 설정으로 redis-cli를 통해 직접 데이터를 보는게 가능
+    @Bean
+    fun redisTemplate(): RedisTemplate<String, Any> =
+        RedisTemplate<String, Any>().apply {
+            keySerializer = StringRedisSerializer()
+            valueSerializer = StringRedisSerializer()
+            connectionFactory = redisConnectionFactory()
+        }
+    
+    companion object {
+        private val log = KotlinLogging.logger {}
+    }
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
@@ -7,6 +7,7 @@ import com.thepan.reservationapiserver.config.security.CustomUserDetailsService
 import com.thepan.reservationapiserver.config.security.JwtTokenAuthenticationFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -23,7 +24,8 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher
 @EnableMethodSecurity
 class SecurityConfig(
     private val tokenService: JwtTokenService,
-    private val userDetailsService: CustomUserDetailsService
+    private val userDetailsService: CustomUserDetailsService,
+    private val redisTemplate: RedisTemplate<String, Any>
 ) {
     
     @Bean
@@ -57,7 +59,14 @@ class SecurityConfig(
                 it.accessDeniedHandler(CustomAccessDeniedHandler())
                 it.authenticationEntryPoint(CustomAuthenticationEntryPoint())
             }
-            .addFilterBefore(JwtTokenAuthenticationFilter(tokenService, userDetailsService), UsernamePasswordAuthenticationFilter::class.java)
+            .addFilterBefore(
+                JwtTokenAuthenticationFilter(
+                    tokenService,
+                    userDetailsService,
+                    redisTemplate
+                ),
+                UsernamePasswordAuthenticationFilter::class.java
+            )
         return http.build()
     }
     

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/jwt/JwtTokenHelper.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/jwt/JwtTokenHelper.kt
@@ -46,13 +46,13 @@ class JwtTokenHelper {
             false
         }
     
+    // 📌 접두사 `Bearer ` 제거
+    fun removeBearer(token: String): String = token.substring(TYPE.length)
+    
     // 📌 Token Decoding
     private fun decodeToken(secretKey: String, token: String): Jws<Claims> = Jwts.parser()
         .setSigningKey(secretKey)
         .parseClaimsJws(removeBearer(token))
-    
-    // 📌 접두사 `Bearer ` 제거
-    private fun removeBearer(token: String): String = token.substring(TYPE.length)
     
     companion object {
         const val TYPE = "Bearer "

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/jwt/JwtTokenService.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/jwt/JwtTokenService.kt
@@ -23,4 +23,10 @@ class JwtTokenService(
     fun extractAccessTokenSubject(token: String): String = jwtTokenHelper.extractSubject(jwtTokenProperties.secretKey, token)
     
     fun extractRefreshTokenSubject(refreshToken: String): String = jwtTokenHelper.extractSubject(jwtTokenProperties.refreshSecretKey, refreshToken)
+    
+    fun getAccessTokenExpiresTime(): Long = 1000 * jwtTokenProperties.expireTime
+    
+    fun getRefreshTokenExpiresTime(): Long = 1000 * jwtTokenProperties.refreshExpireTime
+    
+    fun removeBearerPrefix(token: String): String = jwtTokenHelper.removeBearer(token)
 }

--- a/src/main/kotlin/com/thepan/reservationapiserver/controller/SignApiController.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/controller/SignApiController.kt
@@ -3,10 +3,12 @@ package com.thepan.reservationapiserver.controller
 import com.thepan.reservationapiserver.domain.base.ApiResponse
 import com.thepan.reservationapiserver.domain.sign.dto.SignInRequest
 import com.thepan.reservationapiserver.domain.sign.dto.SignInResponse
+import com.thepan.reservationapiserver.domain.sign.dto.SignOutRequest
 import com.thepan.reservationapiserver.domain.sign.service.SignService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
+import kotlin.math.sign
 
 @RestController
 @RequestMapping("/api/v1/sign")
@@ -20,4 +22,15 @@ class SignApiController(
         @RequestBody
         request: SignInRequest
     ): ApiResponse<SignInResponse> = ApiResponse.success(signService.signIn(request))
+    
+    @PostMapping("/signOut")
+    @ResponseStatus(HttpStatus.OK)
+    fun signOut(
+        @Valid
+        @RequestBody
+        request: SignOutRequest
+    ): ApiResponse<Unit> {
+        signService.signOut(request)
+        return ApiResponse.success()
+    }
 }

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/dto/SignOutRequest.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/dto/SignOutRequest.kt
@@ -1,0 +1,8 @@
+package com.thepan.reservationapiserver.domain.sign.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class SignOutRequest(
+    @field:NotBlank
+    val accessToken: String
+)

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/service/SignService.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/service/SignService.kt
@@ -1,34 +1,78 @@
 package com.thepan.reservationapiserver.domain.sign.service
 
+import com.thepan.reservationapiserver.config.jwt.JwtTokenHelper
 import com.thepan.reservationapiserver.config.jwt.JwtTokenService
 import com.thepan.reservationapiserver.domain.member.entity.Member
 import com.thepan.reservationapiserver.domain.member.repository.MemberRepository
 import com.thepan.reservationapiserver.domain.sign.dto.SignInRequest
 import com.thepan.reservationapiserver.domain.sign.dto.SignInResponse
+import com.thepan.reservationapiserver.domain.sign.dto.SignOutRequest
+import com.thepan.reservationapiserver.exception.AuthenticationEntryPointException
 import com.thepan.reservationapiserver.exception.LoginFailureException
+import com.thepan.reservationapiserver.exception.MemberNotFoundException
+import mu.KotlinLogging
+import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.util.concurrent.TimeUnit
 
 @Service
 class SignService(
     private val memberRepository: MemberRepository,
     private val bCryptPasswordEncoder: BCryptPasswordEncoder,
-    private val jwtTokenService: JwtTokenService
+    private val jwtTokenService: JwtTokenService,
+    private val redisTemplate: RedisTemplate<String, Any>
 ) {
     
     @Transactional(readOnly = true)
     fun signIn(request: SignInRequest): SignInResponse {
         val member = memberRepository.findByEmail(request.email) ?: throw LoginFailureException()
         validatePassword(request.password, member)
-        
+    
         val token = jwtTokenService.createAccessToken(member.id.toString())
         val refreshToken = jwtTokenService.createRefreshToken(member.id.toString())
+        val refreshTokenExpiresTime = jwtTokenService.getRefreshTokenExpiresTime()
+    
+        // Redis 에 Refresh Token 저장
+        redisTemplate.opsForValue().set("RT:${member.email}", refreshToken, refreshTokenExpiresTime, TimeUnit.MILLISECONDS)
+    
         return SignInResponse(token, refreshToken)
+    }
+    
+    @Transactional(readOnly = true)
+    fun signOut(request: SignOutRequest) {
+        // Token 유효성 검사
+        if (!jwtTokenService.validateAccessToken(JwtTokenHelper.TYPE + request.accessToken)) {
+            throw AuthenticationEntryPointException()
+        }
+        
+        // Token 에서 subject 추출
+        val memberId = jwtTokenService.extractAccessTokenSubject(JwtTokenHelper.TYPE + request.accessToken)
+        
+        // 추출한 subject 를 바탕으로 Member 조회
+        val member = memberRepository.findById(
+            memberId.toLong()
+        ).orElseThrow {
+            MemberNotFoundException()
+        }
+        
+        // Redis 에서 해당 Member Email 로 저장된 Refresh Token 이 있는지 여부를 확인 후에 있을 경우 삭제
+        if (redisTemplate.opsForValue()["RT:${member.email}"] != null) {
+            redisTemplate.delete("RT:${member.email}")
+        }
+        
+        // 해당 Access Token 유효시간을 가지고 와서 BlackList 에 저장
+        val expiration = jwtTokenService.getAccessTokenExpiresTime()
+        redisTemplate.opsForValue().set(request.accessToken, "logout", expiration, TimeUnit.MILLISECONDS)
     }
     
     private fun validatePassword(password: String, member: Member) {
         if (!bCryptPasswordEncoder.matches(password, member.password))
             throw LoginFailureException()
+    }
+    
+    companion object {
+        private val log = KotlinLogging.logger {}
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,10 @@ spring:
     console:
       enabled: true
       path: /h2-console
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 jwt:
   issuer: narvis2@naver.com


### PR DESCRIPTION
## 🌸 로그아웃 시 JWT Token Handling
1. `Client` 단에서 `Logout` 시 Local DB 에 저장해 뒀던 Token 을 제거하여 로그아웃하는 방법
    - ⚠️ 단점 : `Client` 에서 유저가 `Token`을 미리 `Copy`를 했다면 계속해서 서버에 요청을 보낼 수 있음

2. 위의 `Copy` 문제를 해결하기 위한 **_BlackList_** 생성
    - `Logout`하고 싶은 `Token`들을 `BlackList`에 모으고, `BlackList`에 `Token`이 들어오면 해당 `Token`을 **_무효화_** 하는 작업을 진행

### 🌹 Redis 사용
- **_Redis(인 메모리 데이터 저장소)_** 를 사용하여 `BlackList`를 `Redis` 에 저장하여 사용

- Cache, Authentication Token, Session 관리 등등 여로 용도로 사용됨
  > - 나중에 핸드폰 인증에 사용될 인증 번호도 Redis 를 사용할 예정

- key-value 형태로 저장되며 만료시간을 함께 넣을 수 있음
  > ## **_📌 참고_**
  > ### ※ Redis 다운
  > - [관련 BLOG](https://herojoon-dev.tistory.com/170)
  > ---
  > ### ※ 로직
  > 1. 로그인 할 때 `Redis`에 `RefreshToken` 저장
  > 2. 로그아웃 할 때 `Redis`의 `Token` **_삭제_** 하고 내가 로그아웃 하고 싶은 `Token`을 만료시간 설정하여 `BlackList`에 추가
    >> - key : AccessToken
    >> - value : logout (아무거나 해두됨)
  > 3. API 요청이 오면 `Token`을 `key`로 사용하여 `Redis`에 접근하고 해당 `key`에 대한 `value` 값이 있으면 `BlackList` 에 추가된 `Token` 으로 간주하고 **_AuthenticationEntryPointException_** 을 발생
  > ---
  > ### ※ 종속성 추가
  > ``` gradle
  > implementation("org.springframework.boot:spring-boot-starter-data-redis")
  > ```
  > ---
  > ### ※ application.yml 설정
  > ``` yml
  > spring:
  >   data:
  >     redis:
  >       host: localhost
  >       port: 6379
  > ```
  > ---
  > ### ※ Redis 저장(set())
  > ``` kotlin
  > val expiration = jwtTokenService.getAccessTokenExpiresTime()
  > redisTemplate.opsForValue().set(request.accessToken, "logout", expiration, TimeUnit.MILLISECONDS)
  > ```
  > - set() 👉 첫 번째 인자부터 순서대로 key, value, 만료시간, 만료시간 단위 
  > ---
  > ### ※ Redis 값 가져오기(get())
  > ``` kotlin
  > val isLogout = redisTemplate.opsForValue()[tokenService.removeBearerPrefix(token)] as? String
  > ```
  > - isLogout 값이 null 이거나, isEmpty() 이면 해당 Token 은 BlackList 에 추가된 Token 이 아니므로 **_인증_** 성공
  > - isLogout 값이 존재하고 비어있지 않으면 해당 Token 은 BlackList 에 추가된 Token 이므로 **_인증_** 실패
  