### PR TITLE
🦋 Naver SENS API를 활용한 핸드폰 인증 구현 🦋

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+application-secret.yml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,8 @@ dependencies {
     // Redis 추가
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     
+    implementation("com.googlecode.json-simple:json-simple:1.1.1")
+    
     runtimeOnly("com.h2database:h2")
     
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/kotlin/com/thepan/reservationapiserver/advice/ExceptionAdvice.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/advice/ExceptionAdvice.kt
@@ -90,4 +90,22 @@ class ExceptionAdvice {
     fun duplicateConferenceSeatException(): ApiResponse<Unit> {
         return ApiResponse.failure(-1010, "중복된 좌석입니다.")
     }
+    
+    @ExceptionHandler(NetworkErrorException::class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    fun networkErrorException(): ApiResponse<Unit> {
+        return ApiResponse.failure(-1011, "네트워크가 원활하지 않습니다. 잠시후 다시 시도해주시기 바랍니다.")
+    }
+    
+    @ExceptionHandler(NaverSMSFailureException::class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    fun naverSMSFailureException(e: NaverSMSFailureException): ApiResponse<Unit> {
+        return ApiResponse.failure(-1012, e.message)
+    }
+    
+    @ExceptionHandler(PhoneAuthCheckFailureException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun phoneAuthCheckFailureException(): ApiResponse<Unit> {
+        return ApiResponse.failure(-1013, "휴대폰 인증에 실패하였습니다.")
+    }
 }

--- a/src/main/kotlin/com/thepan/reservationapiserver/controller/SignApiController.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/controller/SignApiController.kt
@@ -1,14 +1,11 @@
 package com.thepan.reservationapiserver.controller
 
 import com.thepan.reservationapiserver.domain.base.ApiResponse
-import com.thepan.reservationapiserver.domain.sign.dto.SignInRequest
-import com.thepan.reservationapiserver.domain.sign.dto.SignInResponse
-import com.thepan.reservationapiserver.domain.sign.dto.SignOutRequest
+import com.thepan.reservationapiserver.domain.sign.dto.*
 import com.thepan.reservationapiserver.domain.sign.service.SignService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
-import kotlin.math.sign
 
 @RestController
 @RequestMapping("/api/v1/sign")
@@ -31,6 +28,28 @@ class SignApiController(
         request: SignOutRequest
     ): ApiResponse<Unit> {
         signService.signOut(request)
+        return ApiResponse.success()
+    }
+    
+    @PostMapping("/phone")
+    @ResponseStatus(HttpStatus.OK)
+    fun signPhone(
+        @Valid
+        @RequestBody
+        request: PhoneAuthRequest
+    ): ApiResponse<Unit> {
+        signService.sendMobileVerificationCode(request)
+        return ApiResponse.success()
+    }
+    
+    @PostMapping("/phone/check")
+    @ResponseStatus(HttpStatus.OK)
+    fun checkPhone(
+        @Valid
+        @RequestBody
+        request: CheckPhoneAuthRequest
+    ): ApiResponse<Unit> {
+        signService.checkMobileVerificationCode(request)
         return ApiResponse.success()
     }
 }

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/repository/ReservationRepository.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/repository/ReservationRepository.kt
@@ -32,7 +32,6 @@ interface ReservationRepository : JpaRepository<Reservation, Long> {
     /**
      * 📌 지정된 날짜에 예약된 정보 List 가져오기
      * - 좌석 중복 체크에 사용될 것 임
-     * TODO:: r.seat 로 바꾸기
      */
     @Query("SELECT r FROM Reservation r WHERE r.timeType = :timeType AND r.reservationDateTime = :reservationDateTime")
     fun findByTimeTypeAndDateTime(

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/repository/ReservationRepository.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/repository/ReservationRepository.kt
@@ -32,6 +32,7 @@ interface ReservationRepository : JpaRepository<Reservation, Long> {
     /**
      * 📌 지정된 날짜에 예약된 정보 List 가져오기
      * - 좌석 중복 체크에 사용될 것 임
+     * TODO:: r.seat 로 바꾸기
      */
     @Query("SELECT r FROM Reservation r WHERE r.timeType = :timeType AND r.reservationDateTime = :reservationDateTime")
     fun findByTimeTypeAndDateTime(

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/dto/CheckPhoneAuthRequest.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/dto/CheckPhoneAuthRequest.kt
@@ -1,0 +1,14 @@
+package com.thepan.reservationapiserver.domain.sign.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+
+data class CheckPhoneAuthRequest(
+    @field:NotBlank(message = "예약자 성함을 입력해주세요.")
+    val name: String,
+    @field:NotBlank(message = "예약자 휴대폰 번호를 입력해주세요.")
+    @field:Pattern(regexp = "^01([0|1|6|7|8|9])-?([0-9]{3,4})-?([0-9]{4})\$", message = "유효하지 않은 휴대폰 번호입니다.")
+    val phoneNumber: String,
+    @field:NotBlank(message = "인증번호를 입력해주세요.")
+    val authenticationCode: String
+)

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/dto/PhoneAuthRequest.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/dto/PhoneAuthRequest.kt
@@ -1,0 +1,12 @@
+package com.thepan.reservationapiserver.domain.sign.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+
+data class PhoneAuthRequest(
+    @field:NotBlank(message = "예약자 성함을 입력해주세요.")
+    val name: String,
+    @field:NotBlank(message = "예약자 휴대폰 번호를 입력해주세요.")
+    @field:Pattern(regexp = "^01([0|1|6|7|8|9])-?([0-9]{3,4})-?([0-9]{4})\$", message = "유효하지 않은 휴대폰 번호입니다.")
+    val phoneNumber: String
+)

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/service/SignService.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/service/SignService.kt
@@ -4,12 +4,12 @@ import com.thepan.reservationapiserver.config.jwt.JwtTokenHelper
 import com.thepan.reservationapiserver.config.jwt.JwtTokenService
 import com.thepan.reservationapiserver.domain.member.entity.Member
 import com.thepan.reservationapiserver.domain.member.repository.MemberRepository
-import com.thepan.reservationapiserver.domain.sign.dto.SignInRequest
-import com.thepan.reservationapiserver.domain.sign.dto.SignInResponse
-import com.thepan.reservationapiserver.domain.sign.dto.SignOutRequest
-import com.thepan.reservationapiserver.exception.AuthenticationEntryPointException
-import com.thepan.reservationapiserver.exception.LoginFailureException
-import com.thepan.reservationapiserver.exception.MemberNotFoundException
+import com.thepan.reservationapiserver.domain.sign.dto.*
+import com.thepan.reservationapiserver.domain.sms.service.NaverSensV2Service
+import com.thepan.reservationapiserver.exception.*
+import com.thepan.reservationapiserver.utils.PHONE_AUTH_CODE_EXPIRATION
+import com.thepan.reservationapiserver.utils.getPhoneAuthCodeKey
+import com.thepan.reservationapiserver.utils.makeRandomMessage
 import mu.KotlinLogging
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
@@ -22,7 +22,8 @@ class SignService(
     private val memberRepository: MemberRepository,
     private val bCryptPasswordEncoder: BCryptPasswordEncoder,
     private val jwtTokenService: JwtTokenService,
-    private val redisTemplate: RedisTemplate<String, Any>
+    private val redisTemplate: RedisTemplate<String, Any>,
+    private val naverSensV2Service: NaverSensV2Service
 ) {
     
     @Transactional(readOnly = true)
@@ -56,15 +57,65 @@ class SignService(
         ).orElseThrow {
             MemberNotFoundException()
         }
-        
+    
         // Redis 에서 해당 Member Email 로 저장된 Refresh Token 이 있는지 여부를 확인 후에 있을 경우 삭제
         if (redisTemplate.opsForValue()["RT:${member.email}"] != null) {
             redisTemplate.delete("RT:${member.email}")
         }
-        
+    
         // 해당 Access Token 유효시간을 가지고 와서 BlackList 에 저장
         val expiration = jwtTokenService.getAccessTokenExpiresTime()
         redisTemplate.opsForValue().set(request.accessToken, "logout", expiration, TimeUnit.MILLISECONDS)
+    }
+    
+    fun sendMobileVerificationCode(request: PhoneAuthRequest) {
+        val authCodeKey = getPhoneAuthCodeKey(
+            request.name,
+            request.phoneNumber
+        )
+        
+        val beforeCode = redisTemplate.opsForValue()[authCodeKey] as? String
+        
+        // 인증 번호를 재요청 했을 경우 이전에 인증번호 발급받았던 인증번호는 Redis 에서 제거
+        if (!beforeCode.isNullOrEmpty()) {
+            redisTemplate.delete(authCodeKey)
+        }
+        
+        val randomAuthenticationCode = makeRandomMessage()
+        
+        val response = naverSensV2Service.sendSMSMessage(request.phoneNumber, randomAuthenticationCode)
+        
+        if (response.statusCode == "202" && response.statusName == "success") {
+            redisTemplate.opsForValue().set(
+                authCodeKey,
+                randomAuthenticationCode,
+                PHONE_AUTH_CODE_EXPIRATION,
+                TimeUnit.MILLISECONDS
+            )
+        } else {
+            throw NaverSMSFailureException("문자 발송에 실패하였습니다.")
+        }
+    }
+    
+    fun checkMobileVerificationCode(request: CheckPhoneAuthRequest) {
+        val getSavedAuthenticationCode = redisTemplate.opsForValue()[
+            getPhoneAuthCodeKey(
+                request.name,
+                request.phoneNumber
+            )
+        ] as? String
+        
+        when {
+            getSavedAuthenticationCode.isNullOrEmpty() -> {
+                throw PhoneAuthCheckFailureException()
+            }
+            
+            getSavedAuthenticationCode != request.authenticationCode -> {
+                throw PhoneAuthCheckFailureException()
+            }
+        }
+        
+        redisTemplate.delete(getPhoneAuthCodeKey(request.name, request.phoneNumber))
     }
     
     private fun validatePassword(password: String, member: Member) {

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/sms/dto/NaverSensResponse.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/sms/dto/NaverSensResponse.kt
@@ -1,0 +1,10 @@
+package com.thepan.reservationapiserver.domain.sms.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class NaverSensResponse(
+    @JsonProperty("requestId") val requestId: String,
+    @JsonProperty("requestTime") val requestTime: String,
+    @JsonProperty("statusCode") val statusCode: String,
+    @JsonProperty("statusName") val statusName: String
+)

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/sms/helper/NaverSensHelper.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/sms/helper/NaverSensHelper.kt
@@ -1,0 +1,46 @@
+package com.thepan.reservationapiserver.domain.sms.helper
+
+import org.springframework.stereotype.Component
+import java.nio.charset.UnsupportedCharsetException
+import java.security.InvalidKeyException
+import java.security.NoSuchAlgorithmException
+import java.util.*
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+@Component
+class NaverSensHelper {
+    
+    @Throws(NoSuchAlgorithmException::class, InvalidKeyException::class)
+    fun makeSensSignature(
+        url: String,
+        timestamp: String,
+        method: String,
+        accessKey: String,
+        secretKey: String
+    ): String {
+        val space = " "
+        val newLine = "\n"
+        
+        val message = StringBuilder().apply {
+            append(method)
+            append(space)
+            append(url)
+            append(newLine)
+            append(timestamp)
+            append(newLine)
+            append(accessKey)
+        }.toString()
+        
+        return try {
+            val signingKey = SecretKeySpec(secretKey.toByteArray(Charsets.UTF_8), "HmacSHA256")
+            val mac: Mac = Mac.getInstance("HmacSHA256")
+            mac.init(signingKey)
+            
+            val rawHmac = mac.doFinal(message.toByteArray(Charsets.UTF_8))
+            Base64.getEncoder().encodeToString(rawHmac)
+        } catch (e: UnsupportedCharsetException) {
+            e.toString()
+        }
+    }
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/sms/service/NaverSensV2Service.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/sms/service/NaverSensV2Service.kt
@@ -1,0 +1,135 @@
+package com.thepan.reservationapiserver.domain.sms.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.thepan.reservationapiserver.domain.sms.dto.NaverSensResponse
+import com.thepan.reservationapiserver.domain.sms.helper.NaverSensHelper
+import com.thepan.reservationapiserver.exception.NetworkErrorException
+import mu.KotlinLogging
+import org.json.simple.JSONArray
+import org.json.simple.JSONObject
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import java.io.BufferedReader
+import java.io.DataOutputStream
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.*
+
+@Service
+class NaverSensV2Service(
+    @Value("\${naver_sens.url.base}")
+    private val baseUrl: String,
+    @Value("\${naver_sens.url.end_point}")
+    private val endPoint: String,
+    @Value("\${naver_sens.key.access}")
+    private val accessKey: String,
+    @Value("\${naver_sens.key.secret}")
+    private val secretKey: String,
+    @Value("\${naver_sens.id.service}")
+    private val serviceId: String,
+    private val naverSensHelper: NaverSensHelper
+) {
+    
+    /**
+     * @author choi young-jun
+     * 📌 SMS 문자 보내기
+     * @param phoneNumber : SMS 문자를 받을 사람 전화번호
+     * @param rand : 난수 (인증번호)
+     */
+    fun sendSMSMessage(phoneNumber: String, rand: String): NaverSensResponse {
+        val hostNameUrl = baseUrl
+        var requestUrl = endPoint
+        val requestUrlType = "/messages"
+        val method = "POST"
+        val timestamp = System.currentTimeMillis().toString()
+        requestUrl += serviceId + requestUrlType
+        val apiUrl = hostNameUrl + requestUrl
+        
+        val bodyJson = JSONObject()
+        val toJson = JSONObject()
+        val toArray = JSONArray()
+        
+        // 난수와 함께 전송
+        toJson["content"] = "우회담 본인인증 [$rand]"
+        toJson["to"] = phoneNumber
+        toArray.add(toJson)
+        
+        // 메시지 Type (sms | 1ms)
+        bodyJson["type"] = "sms"
+        bodyJson["content"] = "우회담 본인인증 [$rand]"
+        bodyJson["contentType"] = "COMM" // 일반 메시지
+        bodyJson["countryCode"] = "82" // 국가 번호
+        
+        // 발신번호 * 사전에 인증/등록된 번호만 사용 가능
+        bodyJson["from"] = "01022696141"
+        bodyJson["messages"] = toArray
+        
+        val body = bodyJson.toJSONString()
+        log.info {
+            "💬 SMS 문자 보내기 body 👇 \n $body"
+        }
+        
+        return try {
+            val url = URL(apiUrl)
+            val con = url.openConnection() as HttpURLConnection
+            con.apply {
+                useCaches = false
+                doOutput = true
+                doInput = true
+                setRequestProperty("content-type", "application/json")
+                setRequestProperty("x-ncp-apigw-timestamp", timestamp)
+                setRequestProperty("x-ncp-iam-access-key", accessKey)
+                setRequestProperty(
+                    "x-ncp-apigw-signature-v2",
+                    naverSensHelper.makeSensSignature(
+                        requestUrl,
+                        timestamp,
+                        method,
+                        accessKey,
+                        secretKey
+                    )
+                )
+                requestMethod = method
+                doOutput = true
+            }
+            
+            val wr = DataOutputStream(con.outputStream)
+            wr.write(body.toByteArray())
+            wr.flush()
+            wr.close()
+            
+            val responseCode = con.responseCode
+            val br = if (responseCode == 202) {
+                BufferedReader(InputStreamReader(con.inputStream))
+            } else {
+                BufferedReader(InputStreamReader(con.errorStream))
+            }
+            
+            val response = StringBuffer()
+            var inputLine: String?
+            
+            while (br.readLine().also { inputLine = it } != null) {
+                response.append(inputLine)
+            }
+            
+            br.close()
+            
+            log.info {
+                "💬 SMS 문자 보내기 response 👇 \n $response"
+            }
+            val naverSensResponse = ObjectMapper().readValue(response.toString(), NaverSensResponse::class.java)
+            
+            naverSensResponse
+        } catch (e: Exception) {
+            log.error {
+                "💬 SMS 문자 보내기 Exception 👉 $e, ${e.message}"
+            }
+            throw NetworkErrorException()
+        }
+    }
+    
+    companion object {
+        private val log = KotlinLogging.logger {}
+    }
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/exception/NaverSMSFailureException.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/exception/NaverSMSFailureException.kt
@@ -1,0 +1,3 @@
+package com.thepan.reservationapiserver.exception
+
+class NaverSMSFailureException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/com/thepan/reservationapiserver/exception/NetworkErrorException.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/exception/NetworkErrorException.kt
@@ -1,0 +1,3 @@
+package com.thepan.reservationapiserver.exception
+
+class NetworkErrorException : RuntimeException()

--- a/src/main/kotlin/com/thepan/reservationapiserver/exception/PhoneAuthCheckFailureException.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/exception/PhoneAuthCheckFailureException.kt
@@ -1,0 +1,3 @@
+package com.thepan.reservationapiserver.exception
+
+class PhoneAuthCheckFailureException : RuntimeException()

--- a/src/main/kotlin/com/thepan/reservationapiserver/utils/Constants.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/utils/Constants.kt
@@ -1,0 +1,4 @@
+package com.thepan.reservationapiserver.utils
+
+// 핸드폰 인증번호 유효기간 👉 3분
+const val PHONE_AUTH_CODE_EXPIRATION = 1000L * 60 * 3

--- a/src/main/kotlin/com/thepan/reservationapiserver/utils/Utils.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/utils/Utils.kt
@@ -1,5 +1,7 @@
 package com.thepan.reservationapiserver.utils
 
+import java.util.Random
+
 /**
  * @author choi young-jun
  * 첫 번째 List 의 요소 중 하나라도 두 번째 List 에 포함되는지 여부를 체크하는 함수
@@ -8,3 +10,26 @@ package com.thepan.reservationapiserver.utils
  */
 fun <T> isCheckDuplicatedList(firstList: List<T>, secondList: List<T>): Boolean =
     firstList.any { secondList.contains(it) }
+
+/**
+ * @author choi young-jun
+ * name, phoneNumber 를 바탕으로 Redis 에서
+ * 핸드폰 인증번호를 가져오는 Key 를 만들어서 반환
+ */
+fun getPhoneAuthCodeKey(name: String, phoneNumber: String): String = "PA:${name}:${phoneNumber}"
+
+/**
+ * @author choi young-jun
+ * - 0 ~ 9 사이의 숫자를 사용하여 5자리 랜덤한 숫자를 만들어 반환
+ */
+fun makeRandomMessage(): String {
+    val rand = Random()
+    var numStr = ""
+    
+    for (i in 0 until 6) {
+        val ran = rand.nextInt(10).toString()
+        numStr += ran
+    }
+    
+    return numStr
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 spring:
   profiles:
     active: local
+    include: secret
   jpa:
     show-sql: true
     properties:


### PR DESCRIPTION
## 🌸 Naver SENS API
- 사용자의 핸드폰 번호를 받아 SMS 문자를 날리는데 사용

> **_참고_**
> -
> - [Naver Cloud Platform](https://www.ncloud.com/mypage/manage/auth?auth=%2Fmypage%2Fmanage%2Fauthkey)
> - [Naver Cloud Platform Console](https://console.ncloud.com/sens/project)

### 🌹 전화 번호 인증
- 사용자에게 인증번호 SMS를 보내는 API 생성 👉 /api/v1/sign/phone
- 인증번호 check API 생성 👉 /api/v1/sign/phone/check

> ### **_📌 참고_**
> --- 
> #### 📍 Dependency 추가
> ※ build.gradle.kts
> ``` gradle
> implementation("com.googlecode.json-simple:json-simple:1.1.1")
> ```
> - Naver SENS API를 요청할때 RequestBody 를 만들기 위해 Dependency 추가
> ---

> ---
> ### 📍 로직
> ---
> #### ※ 인증번호 요청 API(/api/v1/sign/phone)
> - 1. Client 에서 사용자의 이름, 전화번호를 바탕으로 /api/v1/sign/phone API 호출
> - 2. Server 는 사용자의 이름, 전화번호를 바탕으로 `Key` 를 만들어 Redis 에서 **_인증번호_** 를 조회
>> - 2-1) 인증번호가 있으면 인증번호 재요청 이므로 이전에 Redis 저장되어있는 **_인증번호_** 는 제거
> - 3. Server Naver SENSE 를 사용하여 인증번호를 보내고 문자 보내기를 성공하면 **_인증번호_** 를 Redis 에 저장
> ---
> #### ※ 인증번호 Check API(/api/v1/sign/phone)
> - 1. Client 에서 사용자의 이름, 전화번호, 인증번호를 바탕으로 /api/v1/sign/phone/check API 호출
> - 2. Server 는 사용자의 이름, 전화번호를 바탕으로 `Key` 를 만들어 Redis 에서 **_인증번호_** 를 조회
>> - 2-1) 인증번호가 없으면 **_휴대폰 인증 실패_**
> - 3. Redis 에 인증번호가 있으면 Params 으로 넘어온 **_인증번호_** 와 Redis 에 저장해뒀던 **_인증번호_** 비교
>> - 3-1) Redis 에 저장되어있는 인증번호와 사용자로부터 넘어온 인증번호가 같으면 **_인증성공_**
> - 4. 인증을 성공하면 Redis 에 저장되어있던 인증번호 삭제
> ---

### 🌹 application-scret.yml 생성 후 gitignore 설정
- Naver SENS API를 사용함에 있어 필요한 `accessKey`, `secretKey`, `serviceId` 등등은 **_application-scret.yml_** 을 생성하여 관리
- **_application-scret.yml_** 내부의 것들은 민감한 데이터 이므로 `.gitignore` 에 등록