### PR TITLE
예약자별 예약횟수 조회하는 API 추가

### DIFF
--- a/src/main/kotlin/com/thepan/reservationapiserver/controller/ReservationApiController.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/controller/ReservationApiController.kt
@@ -50,7 +50,7 @@ class ReservationApiController(
     @ResponseStatus(HttpStatus.OK)
     fun countReservedClients(
         @Valid
-        request:ReservationClientCountRequest
+        request: ReservationClientCountRequest
     ): ApiResponse<List<ReservationClientCountResponseInterface>> =
         ApiResponse.success(reservationService.getReservationClientCount(request))
 }

--- a/src/main/kotlin/com/thepan/reservationapiserver/controller/ReservationApiController.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/controller/ReservationApiController.kt
@@ -2,10 +2,7 @@ package com.thepan.reservationapiserver.controller
 
 import com.thepan.reservationapiserver.domain.base.ApiResponse
 import com.thepan.reservationapiserver.domain.reservation.ReservationService
-import com.thepan.reservationapiserver.domain.reservation.dto.ReservationAllResponse
-import com.thepan.reservationapiserver.domain.reservation.dto.ReservationCreateRequest
-import com.thepan.reservationapiserver.domain.reservation.dto.ReservationSeatListRequest
-import com.thepan.reservationapiserver.domain.reservation.dto.ReservationStatusCondition
+import com.thepan.reservationapiserver.domain.reservation.dto.*
 import com.thepan.reservationapiserver.domain.seat.entity.SeatType
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
@@ -16,7 +13,7 @@ import org.springframework.web.bind.annotation.*
 class ReservationApiController(
     private val reservationService: ReservationService
 ) {
-    
+
     @PostMapping("/reservation")
     @ResponseStatus(HttpStatus.CREATED)
     fun create(
@@ -25,15 +22,15 @@ class ReservationApiController(
         request: ReservationCreateRequest
     ): ApiResponse<Unit> {
         reservationService.create(request)
-    
+
         return ApiResponse.success()
     }
-    
+
     @GetMapping("/reservation")
     @ResponseStatus(HttpStatus.OK)
     fun readAll(): ApiResponse<List<ReservationAllResponse>> =
         ApiResponse.success(reservationService.readAll())
-    
+
     @GetMapping("/reservation/status")
     @ResponseStatus(HttpStatus.OK)
     fun readToCondition(
@@ -41,11 +38,19 @@ class ReservationApiController(
         condition: ReservationStatusCondition
     ): ApiResponse<List<ReservationAllResponse>> =
         ApiResponse.success(reservationService.getReservationStatus(condition))
-    
+
     @GetMapping("/reservation/seats")
     @ResponseStatus(HttpStatus.OK)
     fun readReservedSeatList(
         @Valid
         request: ReservationSeatListRequest
     ): ApiResponse<List<SeatType>> = ApiResponse.success(reservationService.getTargetReservationSeatList(request))
+
+    @GetMapping("/reservation/count")
+    @ResponseStatus(HttpStatus.OK)
+    fun countReservedClients(
+        @Valid
+        request:ReservationClientCountRequest
+    ): ApiResponse<List<ReservationClientCountResponseInterface>> =
+        ApiResponse.success(reservationService.getReservationClientCount(request))
 }

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/ReservationService.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/ReservationService.kt
@@ -3,10 +3,7 @@ package com.thepan.reservationapiserver.domain.reservation
 import com.thepan.reservationapiserver.domain.mapper.toEntity
 import com.thepan.reservationapiserver.domain.mapper.toReservationAllResponseList
 import com.thepan.reservationapiserver.domain.mapper.toSeatTypeList
-import com.thepan.reservationapiserver.domain.reservation.dto.ReservationAllResponse
-import com.thepan.reservationapiserver.domain.reservation.dto.ReservationCreateRequest
-import com.thepan.reservationapiserver.domain.reservation.dto.ReservationSeatListRequest
-import com.thepan.reservationapiserver.domain.reservation.dto.ReservationStatusCondition
+import com.thepan.reservationapiserver.domain.reservation.dto.*
 import com.thepan.reservationapiserver.domain.reservation.repository.ReservationRepository
 import com.thepan.reservationapiserver.domain.seat.entity.Seat
 import com.thepan.reservationapiserver.domain.seat.entity.SeatType
@@ -27,38 +24,38 @@ class ReservationService(
     private val seatRepository: SeatRepository
 ) {
     private val log = KotlinLogging.logger {}
-    
+
     @Transactional
     fun create(request: ReservationCreateRequest) {
         checkIsDuplicateConference(request)
         val seatList = checkIsValidSeatName(request)
         checkIsDuplicateSeat(request)
-    
+
         log.info("🌸 예약 등록 START =========================")
         reservationRepository.save(request.toEntity(seatList))
         log.info("🌸 예약 등록 END =========================")
     }
-    
+
     fun readAll(): List<ReservationAllResponse> = reservationRepository.findAll().toReservationAllResponseList()
-    
+
     fun getReservationStatus(condition: ReservationStatusCondition): List<ReservationAllResponse> =
         reservationRepository.findByReservationDate(condition.dateTime.toLocalDate()).toReservationAllResponseList()
-    
+
     // 📌 특정 날짜에 남아있는 좌석 List 가져오기
     fun getTargetReservationSeatList(request: ReservationSeatListRequest): List<SeatType> {
         val reservedSeatList = getReservationInfoList(request.timeType, request.reservationDateTime)
         val allSeatList = seatRepository.findAll()
-    
+
         return if (reservedSeatList.isEmpty()) {
             allSeatList.map { it.seatType }
         } else {
             // 같은 날짜에 이미 예약되어있는 좌석 제거하고 남아있는 좌석만 가져오기
             val leftReservationList = allSeatList.filterNot { it in reservedSeatList }
-        
+
             leftReservationList.map { it.seatType }
         }
     }
-    
+
     // 📌 중복 예약 체크
     private fun checkIsDuplicateConference(request: ReservationCreateRequest) {
         val isDuplicateReservation = reservationRepository.findByAllCondition(
@@ -67,21 +64,21 @@ class ReservationService(
             timeType = stringToTimeType(request.timeType),
             reservationDateTime = request.reservationDateTime
         ) !== null
-        
+
         if (isDuplicateReservation)
             throw DuplicateConferenceException()
     }
-    
+
     // 📌 Seat 명이 올바른지 체크
     private fun checkIsValidSeatName(request: ReservationCreateRequest): List<Seat> {
         val seatList = seatRepository.findBySeatTypeIn(request.seat.toSeatTypeList())
-        
+
         if (seatList.isEmpty())
             throw SeatNotFoundException()
-        
+
         return seatList
     }
-    
+
     /**
      * 📌 중복된 좌석 체크
      * - 해당 날짜로 조회해서 예약 정보가 없으면 👉 좌석이 모두 있다는 의미, 더 이상 밑에 로직 탈 필요없이 return 처리
@@ -89,25 +86,25 @@ class ReservationService(
      */
     private fun checkIsDuplicateSeat(request: ReservationCreateRequest) {
         val selectedSeatList = checkIsValidSeatName(request)
-    
+
         val allSeatList = seatRepository.findAll()
-    
+
         if (allSeatList.isEmpty())
             throw SeatNotFoundException()
-    
+
         val reservedSeatList = getReservationInfoList(
             request.timeType,
             request.reservationDateTime
         )
-    
+
         if (reservedSeatList.isEmpty()) return
-    
+
         val checkSeat = isCheckDuplicatedList(selectedSeatList, reservedSeatList)
-    
+
         if (checkSeat)
             throw DuplicateConferenceSeatException()
     }
-    
+
     private fun getReservationInfoList(
         timeType: String,
         reservationDateTime: LocalDateTime
@@ -115,6 +112,12 @@ class ReservationService(
         stringToTimeType(timeType),
         reservationDateTime
     ).map { it.seat }
-    
+
     private fun stringToTimeType(timeType: String): TimeType = TimeType.valueOf(timeType)
+
+    fun getReservationClientCount(
+        request: ReservationClientCountRequest
+    ): List<ReservationClientCountResponseInterface> =
+        reservationRepository.findByUserNameAndPhoneNumber(request.name, request.phoneNumber)
+
 }

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/dto/ReservationClientCountRequest.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/dto/ReservationClientCountRequest.kt
@@ -1,6 +1,6 @@
 package com.thepan.reservationapiserver.domain.reservation.dto
 
 data class ReservationClientCountRequest(
-    val name: String,
-    val phoneNumber: String
+    val name: String?,
+    val phoneNumber: String?
 )

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/dto/ReservationClientCountRequest.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/dto/ReservationClientCountRequest.kt
@@ -1,0 +1,6 @@
+package com.thepan.reservationapiserver.domain.reservation.dto
+
+data class ReservationClientCountRequest(
+    val name: String,
+    val phoneNumber: String
+)

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/dto/ReservationClientCountResponseInterface.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/dto/ReservationClientCountResponseInterface.kt
@@ -1,0 +1,7 @@
+package com.thepan.reservationapiserver.domain.reservation.dto
+
+interface ReservationClientCountResponseInterface {
+    fun getName(): String
+    fun getPhoneNumber(): String
+    fun getReservationCount(): Int
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/repository/ReservationRepository.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/repository/ReservationRepository.kt
@@ -1,5 +1,6 @@
 package com.thepan.reservationapiserver.domain.reservation.repository
 
+import com.thepan.reservationapiserver.domain.reservation.dto.ReservationClientCountResponseInterface
 import com.thepan.reservationapiserver.domain.reservation.entity.Reservation
 import com.thepan.reservationapiserver.domain.reservation.entity.ReservationSeat
 import com.thepan.reservationapiserver.domain.seat.entity.TimeType
@@ -12,7 +13,7 @@ import java.time.LocalDateTime
 interface ReservationRepository : JpaRepository<Reservation, Long> {
     @Query("SELECT r FROM Reservation r WHERE CAST(r.reservationDateTime AS date) = :date")
     fun findByReservationDate(date: LocalDate): List<Reservation>
-    
+
     // 📌 내 예약 정보를 가져옴
     @Query("SELECT r FROM Reservation r WHERE r.id = :reservationId AND r.timeType = :timeType AND r.reservationDateTime = :reservationDateTime")
     fun findByReservationIdAndTimeTypeAndDateTime(
@@ -20,7 +21,7 @@ interface ReservationRepository : JpaRepository<Reservation, Long> {
         @Param("timeType") timeType: TimeType,
         @Param("reservationDateTime") reservationDateTime: LocalDateTime
     ): Reservation?
-    
+
     // 📌 예약 중복 체크에 사용됨
     @Query("SELECT r FROM Reservation r WHERE r.name = :name AND r.phoneNumber = :phoneNumber AND r.timeType = :timeType AND r.reservationDateTime = :reservationDateTime")
     fun findByAllCondition(
@@ -29,7 +30,7 @@ interface ReservationRepository : JpaRepository<Reservation, Long> {
         @Param("timeType") timeType: TimeType,
         @Param("reservationDateTime") reservationDateTime: LocalDateTime
     ): Reservation?
-    
+
     /**
      * 📌 지정된 날짜에 예약된 정보 List 가져오기
      * - 좌석 중복 체크에 사용될 것 임
@@ -39,4 +40,14 @@ interface ReservationRepository : JpaRepository<Reservation, Long> {
         @Param("timeType") timeType: TimeType,
         @Param("reservationDateTime") reservationDateTime: LocalDateTime
     ): MutableSet<ReservationSeat>
+
+    /**
+     * 📌 해당 이름과, 전화번호로 예약이 몇번 됐는지 Count List 가져오기
+     * - 받은 파람값이 있으면 해당 손님의 예약 횟수를, 없다면 전체 손님의 예약 횟수를 가져옴
+     */
+    @Query("SELECT r.name AS name , r.phoneNumber AS phoneNumber, count(r.name) AS reservationCount FROM Reservation r WHERE r.name LIKE %:name% AND r.phoneNumber LIKE %:phoneNumber% GROUP BY r.name")
+    fun findByUserNameAndPhoneNumber(
+        @Param("name") name: String,
+        @Param("phoneNumber") phoneNumber: String
+    ): List<ReservationClientCountResponseInterface>
 }

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/repository/ReservationRepository.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/repository/ReservationRepository.kt
@@ -47,7 +47,7 @@ interface ReservationRepository : JpaRepository<Reservation, Long> {
      */
     @Query("SELECT r.name AS name , r.phoneNumber AS phoneNumber, count(r.name) AS reservationCount FROM Reservation r WHERE r.name LIKE %:name% AND r.phoneNumber LIKE %:phoneNumber% GROUP BY r.name")
     fun findByUserNameAndPhoneNumber(
-        @Param("name") name: String,
-        @Param("phoneNumber") phoneNumber: String
+        @Param("name") name: String?,
+        @Param("phoneNumber") phoneNumber: String?
     ): List<ReservationClientCountResponseInterface>
 }


### PR DESCRIPTION
##  ✅ 예약자별 예약 횟수 조회하는 기능 추가
- endPoint 👉 GET `/reservation/count`
- param 👉 name, phoneNumber

## 쿼리문의 결과값이 dto, entity는 없는 다른 값들을 불러와야할때 
- 예를들어 합계나, 평균값이나 등등 GroupBy를 이용해서 리턴값을 받아야할때  
- [프로젝션](https://thalals.tistory.com/359)
> 쿼리문의 리턴값으로 받는거에 대해서 AS로 컬럼명을 지정해주고 해당 값들을 가지는 인터페이스를 생성해서 리턴값으로 넘겨줘야함
> 다른 방법도 많이 있지만 자바를 코틀린으로 변환하는 과정이 익숙하지 않아서 해당 방법으로 진행함
- 🏴 ReservationRepo.kt
```kt
@Query("SELECT 
r.name AS name, 
r.phoneNumber AS phoneNumber, 
count(r.name) AS reservationCount 
FROM Reservation r 
WHERE r.name LIKE %:name% 
AND r.phoneNumber LIKE %:phoneNumber% 
GROUP BY r.name")
    fun findByUserNameAndPhoneNumber(
        @Param("name") name: String,
        @Param("phoneNumber") phoneNumber: String
    ): List<ReservationClientCountResponseInterface>
```

- 🏴 ReservationClientCountResponseInterface.kt
```kt
interface ReservationClientCountResponseInterface {
    fun getName(): String
    fun getPhoneNumber(): String
    fun getReservationCount(): Int
}
```