### PR TITLE
🦋 공지사항 API 추가 🦋

### DIFF
--- a/src/main/kotlin/com/thepan/reservationapiserver/InitDB.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/InitDB.kt
@@ -49,6 +49,7 @@ class InitDB(
             phoneNumber = "01022696141",
             password = bCryptPasswordEncoder.encode("dudwns@651342"),
             roles = listOf(
+                roleRepository.findByRoleType(RoleType.ROLE_ADMIN) ?: throw RoleNotFoundException(),
                 roleRepository.findByRoleType(RoleType.ROLE_MASTER) ?: throw RoleNotFoundException()
             )
         )

--- a/src/main/kotlin/com/thepan/reservationapiserver/advice/ExceptionAdvice.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/advice/ExceptionAdvice.kt
@@ -108,4 +108,23 @@ class ExceptionAdvice {
     fun phoneAuthCheckFailureException(): ApiResponse<Unit> {
         return ApiResponse.failure(-1013, "휴대폰 인증에 실패하였습니다.")
     }
+    
+    @ExceptionHandler(UnsupportedImageFormatException::class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    fun unsupportedImageFormatException(): ApiResponse<Unit> {
+        return ApiResponse.failure(-1014, "지원하는 확장자가 아닙니다.")
+    }
+    
+    @ExceptionHandler(FileUploadFailureException::class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    fun fileUploadFailureException(e: FileUploadFailureException): ApiResponse<Unit> {
+        log.error("파일 업로드 실패 에러 👉 ${e.message}")
+        return ApiResponse.failure(-1015, "파일 업로드에 실패하였습니다.");
+    }
+    
+    @ExceptionHandler(NoticeNotFoundException::class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    fun noticeNotFoundException(): ApiResponse<Unit> {
+        return ApiResponse.failure(-1016, "요청하신 공지사항을 찾을 수 없습니다.");
+    }
 }

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
@@ -47,9 +47,14 @@ class SecurityConfig(
                 auth.requestMatchers(
                     "/api/v1/sign/**",
                     "/api/v1/seats/**",
-                    "/api/v1/reservation/seats"
+                    "/api/v1/reservation/seats",
+                    "/api/v1/notices"
                 ).permitAll()
+                    .requestMatchers(HttpMethod.GET, "/image/**").permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/v1/reservation").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/api/v1/notice").hasRole("ADMIN")
+                    .requestMatchers(HttpMethod.DELETE, "/api/v1/notice/{id}").hasRole("ADMIN")
+                    .requestMatchers(HttpMethod.PUT, "/api/v1/notice/{id}").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.GET, "/api/v1/reservation").hasRole("MASTER")
                     .requestMatchers(HttpMethod.GET, "/api/v1/reservation/status").hasRole("MASTER")
                     .anyRequest() // 위의 요청을 제외한 나머지 요청

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/WebConfig.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/WebConfig.kt
@@ -1,0 +1,22 @@
+package com.thepan.reservationapiserver.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.CacheControl
+import org.springframework.web.servlet.config.annotation.EnableWebMvc
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import java.time.Duration
+
+@EnableWebMvc
+@Configuration
+class WebConfig(
+    @Value("\${upload.image.location}")
+    private val location: String
+) : WebMvcConfigurer {
+    override fun addResourceHandlers(registry: ResourceHandlerRegistry) {
+        registry.addResourceHandler("/image/**")
+            .addResourceLocations("file:$location") // 파일 시스템의 location 경로에서 파일에 접근
+            .setCacheControl(CacheControl.maxAge(Duration.ofHours(1L)).cachePublic())
+    }
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/controller/NoticeApiController.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/controller/NoticeApiController.kt
@@ -1,0 +1,61 @@
+package com.thepan.reservationapiserver.controller
+
+import com.thepan.reservationapiserver.domain.base.ApiResponse
+import com.thepan.reservationapiserver.domain.notice.dto.NoticeAllResponse
+import com.thepan.reservationapiserver.domain.notice.dto.NoticeCreateRequest
+import com.thepan.reservationapiserver.domain.notice.dto.NoticeUpdateRequest
+import com.thepan.reservationapiserver.domain.notice.service.NoticeService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1")
+class NoticeApiController(
+    private val noticeService: NoticeService
+) {
+    
+    /**
+     * @ModelAttribute
+     * - 게시글 데이터를 이미지와 함께 전달받을 수 있도록,
+     *   요청하는 Content-Type이 multipart/form-data를 이용
+     *
+     * @ModelAttribute 에 대해 validation 제약 조건이 위배되면, BindException 예외가 발생
+     */
+    @PostMapping("/notice")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun create(
+        @Valid
+        @ModelAttribute
+        request: NoticeCreateRequest
+    ): ApiResponse<Unit> {
+        noticeService.create(request)
+        return ApiResponse.success()
+    }
+    
+    @GetMapping("/notices")
+    @ResponseStatus(HttpStatus.OK)
+    fun readAll(): ApiResponse<List<NoticeAllResponse>> = ApiResponse.success(noticeService.readAll())
+    
+    @DeleteMapping("/notice/{id}")
+    @ResponseStatus(HttpStatus.OK)
+    fun delete(
+        @PathVariable id: Long
+    ): ApiResponse<Unit> {
+        noticeService.delete(id)
+        return ApiResponse.success()
+    }
+    
+    @PutMapping("/notice/{id}")
+    @ResponseStatus(HttpStatus.OK)
+    fun update(
+        @PathVariable
+        id: Long,
+        @Valid
+        @ModelAttribute
+        request: NoticeUpdateRequest
+    ): ApiResponse<Unit> {
+        noticeService.update(id, request)
+        return ApiResponse.success()
+    }
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/file/FileService.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/file/FileService.kt
@@ -1,0 +1,8 @@
+package com.thepan.reservationapiserver.domain.file
+
+import org.springframework.web.multipart.MultipartFile
+
+interface FileService {
+    fun upload(file: MultipartFile, filename: String)
+    fun delete(filename: String)
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/file/LocalFileServiceImpl.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/file/LocalFileServiceImpl.kt
@@ -1,0 +1,37 @@
+package com.thepan.reservationapiserver.domain.file
+
+import com.thepan.reservationapiserver.exception.FileUploadFailureException
+import jakarta.annotation.PostConstruct
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.web.multipart.MultipartFile
+import java.io.File
+import java.io.IOException
+
+@Service
+class LocalFileServiceImpl(
+    @Value("\${upload.image.location}")
+    private val location: String
+) : FileService {
+    // 파일을 업로드할 디렉토리를 생성
+    @PostConstruct
+    fun postConstruct() {
+        val dir = File(location)
+        if (!dir.exists()) {
+            dir.mkdir()
+        }
+    }
+    
+    // MultipartFile 을 실제 파일로 지정된 위치에 저장
+    override fun upload(file: MultipartFile, filename: String) {
+        try {
+            file.transferTo(File(location + filename))
+        } catch (e: IOException) {
+            throw FileUploadFailureException(e)
+        }
+    }
+    
+    override fun delete(filename: String) {
+        File(location + filename).delete()
+    }
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/mapper/OjbectMapper.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/mapper/OjbectMapper.kt
@@ -5,6 +5,11 @@ import com.thepan.reservationapiserver.domain.member.dto.MyMemberInfoResponse
 import com.thepan.reservationapiserver.domain.member.entity.Member
 import com.thepan.reservationapiserver.domain.member.entity.MemberRole
 import com.thepan.reservationapiserver.domain.member.entity.RoleType
+import com.thepan.reservationapiserver.domain.notice.dto.NoticeAllResponse
+import com.thepan.reservationapiserver.domain.notice.dto.NoticeCreateRequest
+import com.thepan.reservationapiserver.domain.notice.dto.NoticeImageResponse
+import com.thepan.reservationapiserver.domain.notice.entity.Notice
+import com.thepan.reservationapiserver.domain.notice.entity.NoticeImage
 import com.thepan.reservationapiserver.domain.reservation.dto.ReservationAllResponse
 import com.thepan.reservationapiserver.domain.reservation.dto.ReservationCreateRequest
 import com.thepan.reservationapiserver.domain.reservation.entity.Reservation
@@ -90,3 +95,35 @@ private fun List<RoleType>.toRoleType(): RoleType =
         
         else -> RoleType.ROLE_STOP
     }
+
+fun NoticeCreateRequest.toEntity(member: Member): Notice = Notice(
+    title = this.title,
+    content = this.content,
+    member = member
+).apply {
+    addImages(
+        this@toEntity.images.map {
+            NoticeImage(uniqueName = "", originName = it.originalFilename!!)
+        }
+    )
+}
+
+fun List<Notice>.toNoticeAllResponseList(): List<NoticeAllResponse> = map {
+    NoticeAllResponse(
+        id = it.id,
+        title = it.title,
+        content = it.content,
+        member = it.member.toMyMemberInfoResponse(),
+        images = it.images.toNoticeImageResponseList(),
+        createdAt = it.createdAt,
+        modifiedAt = it.modifiedAt
+    )
+}
+
+private fun List<NoticeImage>.toNoticeImageResponseList(): List<NoticeImageResponse> = map {
+    NoticeImageResponse(
+        id = it.id,
+        originName = it.originName,
+        uniqueName = it.uniqueName
+    )
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/member/entity/Member.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/member/entity/Member.kt
@@ -1,6 +1,7 @@
 package com.thepan.reservationapiserver.domain.member.entity
 
 import com.thepan.reservationapiserver.domain.base.BaseEntity
+import com.thepan.reservationapiserver.domain.notice.entity.Notice
 import jakarta.persistence.*
 
 @Entity
@@ -23,6 +24,8 @@ class Member(
     var password: String,
     @OneToMany(mappedBy = "member", cascade = [CascadeType.ALL], orphanRemoval = true)
     var roles: MutableSet<MemberRole> = mutableSetOf(),
+    @OneToMany(mappedBy = "member", cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
+    var noticeList: MutableList<Notice> = ArrayList()
 ) : BaseEntity() {
     constructor(
         name: String,

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/member/entity/Member.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/member/entity/Member.kt
@@ -1,7 +1,6 @@
 package com.thepan.reservationapiserver.domain.member.entity
 
 import com.thepan.reservationapiserver.domain.base.BaseEntity
-import com.thepan.reservationapiserver.domain.notice.entity.Notice
 import jakarta.persistence.*
 
 @Entity
@@ -23,9 +22,7 @@ class Member(
     var phoneNumber: String,
     var password: String,
     @OneToMany(mappedBy = "member", cascade = [CascadeType.ALL], orphanRemoval = true)
-    var roles: MutableSet<MemberRole> = mutableSetOf(),
-    @OneToMany(mappedBy = "member", cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
-    var noticeList: MutableList<Notice> = ArrayList()
+    var roles: MutableSet<MemberRole> = mutableSetOf()
 ) : BaseEntity() {
     constructor(
         name: String,

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/notice/dto/ImageUpdatedResult.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/notice/dto/ImageUpdatedResult.kt
@@ -1,0 +1,10 @@
+package com.thepan.reservationapiserver.domain.notice.dto
+
+import com.thepan.reservationapiserver.domain.notice.entity.NoticeImage
+import org.springframework.web.multipart.MultipartFile
+
+data class ImageUpdatedResult(
+    val addedImageFiles: List<MultipartFile>,
+    val addedImages: List<NoticeImage>,
+    val deletedImages: List<NoticeImage>
+)

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/notice/dto/NoticeAllResponse.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/notice/dto/NoticeAllResponse.kt
@@ -1,0 +1,17 @@
+package com.thepan.reservationapiserver.domain.notice.dto
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.thepan.reservationapiserver.domain.member.dto.MyMemberInfoResponse
+import java.time.LocalDateTime
+
+data class NoticeAllResponse(
+    val id: Long?,
+    val title: String,
+    val content: String,
+    val member: MyMemberInfoResponse,
+    val images: List<NoticeImageResponse>,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    val createdAt: LocalDateTime?,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    val modifiedAt: LocalDateTime?,
+)

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/notice/dto/NoticeCreateRequest.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/notice/dto/NoticeCreateRequest.kt
@@ -1,0 +1,12 @@
+package com.thepan.reservationapiserver.domain.notice.dto
+
+import jakarta.validation.constraints.NotBlank
+import org.springframework.web.multipart.MultipartFile
+
+data class NoticeCreateRequest(
+    @field:NotBlank(message = "제목을 입력해주세요.")
+    val title: String,
+    @field:NotBlank(message = "내용을 입력해주세요.")
+    val content: String,
+    val images: List<MultipartFile> = ArrayList(),
+)

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/notice/dto/NoticeImageResponse.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/notice/dto/NoticeImageResponse.kt
@@ -1,0 +1,7 @@
+package com.thepan.reservationapiserver.domain.notice.dto
+
+data class NoticeImageResponse(
+    val id: Long?,
+    val originName: String,
+    val uniqueName: String
+)

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/notice/dto/NoticeUpdateRequest.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/notice/dto/NoticeUpdateRequest.kt
@@ -1,0 +1,10 @@
+package com.thepan.reservationapiserver.domain.notice.dto
+
+import org.springframework.web.multipart.MultipartFile
+
+data class NoticeUpdateRequest(
+    val title: String,
+    val content: String,
+    val addedImages: List<MultipartFile> = listOf(), // 추가된 Image List
+    val deletedImages: List<Long> = listOf() // 제거된 Image id List
+)

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/notice/entity/Notice.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/notice/entity/Notice.kt
@@ -1,0 +1,76 @@
+package com.thepan.reservationapiserver.domain.notice.entity
+
+import com.thepan.reservationapiserver.domain.base.BaseEntity
+import com.thepan.reservationapiserver.domain.member.entity.Member
+import com.thepan.reservationapiserver.domain.notice.dto.ImageUpdatedResult
+import com.thepan.reservationapiserver.domain.notice.dto.NoticeUpdateRequest
+import jakarta.persistence.*
+import org.springframework.web.multipart.MultipartFile
+
+@Entity
+class Notice(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "noticeId")
+    var id: Long? = null,
+    @Column(nullable = false)
+    var title: String,
+    @Column(nullable = false)
+    var content: String,
+    @ManyToOne
+    @JoinColumn(name = "memberId")
+    var member: Member,
+    /**
+     * 📌 다대일 양방향
+     * PERSIST 👉 Notice Entity 가 저장되면서 Notice Image Entity 도 같이 저장됨
+     * mappedBy = "notice" 👉 참조하는 Entity 에 있는 변수 명
+     */
+    @OneToMany(mappedBy = "notice", cascade = [CascadeType.PERSIST], orphanRemoval = true)
+    var images: MutableList<NoticeImage> = ArrayList()
+) : BaseEntity() {
+    fun addImages(added: List<NoticeImage>) { // 5
+        added.forEach { i ->
+            this.images.add(i)
+            i.initNotice(this)
+        }
+    }
+    
+    fun update(request: NoticeUpdateRequest): ImageUpdatedResult {
+        this.title = request.title
+        this.content = request.content
+        
+        val result = findImageUpdatedResult(request.addedImages, request.deletedImages)
+        addImages(result.addedImages)
+        deleteImage(result.deletedImages)
+        
+        return result
+    }
+    
+    private fun deleteImage(deleted: List<NoticeImage>) {
+        deleted.forEach { item ->
+            this.images.remove(item)
+        }
+    }
+    
+    private fun findImageUpdatedResult(
+        addedImageFiles: List<MultipartFile>,
+        deletedImageIds: List<Long>
+    ): ImageUpdatedResult {
+        val addedImages = convertImageFilesToImages(addedImageFiles)
+        val deletedImages = convertImageIdsToImages(deletedImageIds)
+        return ImageUpdatedResult(addedImageFiles, addedImages, deletedImages)
+    }
+    
+    private fun convertImageIdsToImages(imageIds: List<Long>): List<NoticeImage> =
+        imageIds.mapNotNull { convertImageIdToImage(it) }
+    
+    private fun convertImageIdToImage(id: Long): NoticeImage? =
+        this.images.find { it.id == id }
+    
+    private fun convertImageFilesToImages(imageFiles: List<MultipartFile>): List<NoticeImage> =
+        imageFiles.mapNotNull { imageFile ->
+            imageFile.originalFilename?.let {
+                NoticeImage(uniqueName = "", originName = it)
+            }
+        }
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/notice/entity/NoticeImage.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/notice/entity/NoticeImage.kt
@@ -1,0 +1,59 @@
+package com.thepan.reservationapiserver.domain.notice.entity
+
+import com.thepan.reservationapiserver.domain.base.BaseEntity
+import com.thepan.reservationapiserver.exception.UnsupportedImageFormatException
+import jakarta.persistence.*
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
+import java.util.*
+
+@Entity
+class NoticeImage(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+    @Column(nullable = false)
+    var uniqueName: String,
+    @Column(nullable = false)
+    var originName: String,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "noticeId")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    var notice: Notice? = null
+) : BaseEntity() {
+    init {
+        this.uniqueName = generateUniqueName(extractExtension(originName))
+    }
+    
+    // Notice 의 연관 관계에 대한 정보가 없다면 이를 등록
+    fun initNotice(notice: Notice) {
+        if (this.notice == null) {
+            this.notice = notice
+        }
+    }
+    
+    private fun generateUniqueName(extension: String): String = UUID.randomUUID().toString() + "." + extension
+    
+    // 이미지 이름에서 확장자를 추출
+    private fun extractExtension(originName: String): String {
+        try {
+            val ext = originName.substring(originName.lastIndexOf(".") + 1)
+            if (isSupportedFormat(ext))
+                return ext
+        } catch (e: StringIndexOutOfBoundsException) {
+            throw UnsupportedImageFormatException()
+        }
+        
+        throw UnsupportedImageFormatException()
+    }
+    
+    // 지원하는 확장자인지 확인
+    private fun isSupportedFormat(ext: String): Boolean = supportedExtension.any {
+        it.equals(ext, ignoreCase = true)
+    }
+    
+    companion object {
+        // 해당 이미지가 지원하는 이미지 확장자
+        private val supportedExtension = arrayOf("jpg", "jpeg", "gif", "bmp", "png")
+    }
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/notice/respository/NoticeRepository.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/notice/respository/NoticeRepository.kt
@@ -1,0 +1,9 @@
+package com.thepan.reservationapiserver.domain.notice.respository
+
+import com.thepan.reservationapiserver.domain.notice.entity.Notice
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface NoticeRepository : JpaRepository<Notice, Long> {
+    
+    fun findByMemberId(memberId: Long): List<Notice>
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/notice/service/NoticeService.kt
@@ -1,0 +1,74 @@
+package com.thepan.reservationapiserver.domain.notice.service
+
+import com.thepan.reservationapiserver.config.security.SecurityUtils
+import com.thepan.reservationapiserver.domain.file.FileService
+import com.thepan.reservationapiserver.domain.mapper.toEntity
+import com.thepan.reservationapiserver.domain.mapper.toNoticeAllResponseList
+import com.thepan.reservationapiserver.domain.member.repository.MemberRepository
+import com.thepan.reservationapiserver.domain.notice.dto.NoticeAllResponse
+import com.thepan.reservationapiserver.domain.notice.dto.NoticeCreateRequest
+import com.thepan.reservationapiserver.domain.notice.dto.NoticeUpdateRequest
+import com.thepan.reservationapiserver.domain.notice.entity.Notice
+import com.thepan.reservationapiserver.domain.notice.entity.NoticeImage
+import com.thepan.reservationapiserver.domain.notice.respository.NoticeRepository
+import com.thepan.reservationapiserver.exception.MemberNotFoundException
+import com.thepan.reservationapiserver.exception.NoticeNotFoundException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.multipart.MultipartFile
+
+@Service
+class NoticeService(
+    private val noticeRepository: NoticeRepository,
+    private val memberRepository: MemberRepository,
+    private val fileService: FileService
+) {
+    
+    @Transactional
+    fun create(request: NoticeCreateRequest) {
+        val writerMemberId = SecurityUtils.getAuthorizedMemberId()
+        val writer = memberRepository.findById(writerMemberId.toLong()).orElseThrow {
+            MemberNotFoundException()
+        }
+        
+        val notice = noticeRepository.save(request.toEntity(writer))
+    
+        uploadImage(notice.images, request.images)
+    }
+    
+    fun readAll(): List<NoticeAllResponse> =
+        noticeRepository.findAll().toNoticeAllResponseList()
+    
+    @Transactional
+    fun delete(id: Long) {
+        val notice = getNoticeFindById(id)
+        deleteImage(notice.images)
+        noticeRepository.delete(notice)
+    }
+    
+    @Transactional
+    fun update(id: Long, request: NoticeUpdateRequest) {
+        val notice = getNoticeFindById(id)
+        val result = notice.update(request)
+    
+        uploadImage(result.addedImages, result.addedImageFiles)
+        deleteImage(result.deletedImages)
+    }
+    
+    private fun getNoticeFindById(id: Long): Notice = noticeRepository.findById(id).orElseThrow { NoticeNotFoundException() }
+    
+    private fun uploadImage(
+        images: List<NoticeImage>,
+        fileImages: List<MultipartFile>
+    ) {
+        images.indices.forEachIndexed { index, _ ->
+            fileService.upload(fileImages[index], images[index].uniqueName)
+        }
+    }
+    
+    private fun deleteImage(images: List<NoticeImage>) {
+        images.forEach { item ->
+            fileService.delete(item.uniqueName)
+        }
+    }
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/exception/FileUploadFailureException.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/exception/FileUploadFailureException.kt
@@ -1,0 +1,3 @@
+package com.thepan.reservationapiserver.exception
+
+class FileUploadFailureException(cause: Throwable) : RuntimeException(cause)

--- a/src/main/kotlin/com/thepan/reservationapiserver/exception/NoticeNotFoundException.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/exception/NoticeNotFoundException.kt
@@ -1,0 +1,3 @@
+package com.thepan.reservationapiserver.exception
+
+class NoticeNotFoundException : RuntimeException()

--- a/src/main/kotlin/com/thepan/reservationapiserver/exception/UnsupportedImageFormatException.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/exception/UnsupportedImageFormatException.kt
@@ -1,0 +1,3 @@
+package com.thepan.reservationapiserver.exception
+
+class UnsupportedImageFormatException : RuntimeException()

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,3 @@
+upload:
+  image:
+    location: ///Users/choiyoungjun/Desktop/image/

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,9 @@ spring:
       host: localhost
       port: 6379
 
+  servlet.multipart.max-file-size: 5MB
+  servlet.multipart.max-request-size: 5MB
+
 jwt:
   issuer: narvis2@naver.com
   secret_key: study-springboot


### PR DESCRIPTION
## 🌸 공지사항 기능 추가
- `MASTER`나 `ADMIN`만 공지사항을 생성할 수 있고 이미지 List를 첨부할 수 있음

> ---
> ### 📌 참고
> --- 
> #### 📍 RDB
> ![](https://github.com/narvis2/Reservation-Api-Server/assets/74344026/f2fc1ced-d6da-4794-8006-24cee3a50bea)
> - [예약 시스템 RDB](https://www.erdcloud.com/d/R7YJv6TdpFrD7ey9A)
> 
> ※ `Notice(공지사항 Entity)` 와 `NoticeImage(공지사항 이미지 Entity)`의 관계
> - Notice : NoticeImage 👉 1 : N
> - NoticeIamge : Notice 👉 N : 1
> - Notice Entity 에 `@OneToMany` 를 사용하고 NoticeImage Entity 에서는 Notice Entity 의 id 를 FK로 참조하면서 `@ManyToOne` 을 사용
> - 즉, `@OneToMany` 양방향 매핑 적용
> - NoticeImage Entity 에 @OnDelete(action = OnDeleteAction.CASCADE) 를 적용하여 Notice Entity 가 제거되면 NoticeImage Entity 또한 같이 제거되도록 했음
>> ※ code 
>> ``` kotlin
>> class NoticeImage(
>>     // ....
>>     @ManyToOne(fetch = FetchType.LAZY)
>>     @JoinColumn(name = "noticeId")
>>     @OnDelete(action = OnDeleteAction.CASCADE)
>>     var notice: Notice? = null
>>     // ....
>> )
>> ```
>
> ※ `Member(유저 Entity)` 와 `Notice(공지사항 Entity)`
> - Member : Notice 👉 1 : N
> - Notice : Member 👉 N : 1
> - Notice Entity 에서 Member Entity 의 id 를 FK로 참조하면서 `@ManyToOne` 사용
> - 즉, `@ManyToOne` 단방향 매핑 적용
> ---

### 🌹 Create
- POST `/api/v1/notice` 
  > - 이미지와 데이터들을 같이 받아오기 위해 @ModelAttribute 를 사용하여 Content-Type 에 multipart/form-data 넣어서 데이터를 요청할 수 있음
- `MASTER`나 `ADMIN`만 공지사항을 **_생성_** 할 수 있고 Image List를 첨부할 수 있음
- Image 는 `Users/***/Desktop/image/` 에 저장됨
- 인증 🅾️
- 인가 🅾️

### 🌹 Read
- GET `/api/v1/notices`
- 인증/인가를 거치지 않고 **_모든 유저_** 가 공지사항 List를 가져올 수 있음
- 인증 ❌
- 인가 ❌

### 🌹 Update
- PUT `/api/v1/notice/{1}`
  > - 이미지와 데이터들을 같이 받아오기 위해 @ModelAttribute 를 사용하여 Content-Type 에 multipart/form-data 넣어서 데이터를 요청할 수 있음
- `MASTER`나 `ADMIN`만 공지사항을 **_수정_** 할 수 있음
  > 📌 참고
  > -
  > #### 📍 이미지 수정
  > - 1. 수정하려는 `Image` 들의 `id` 와 수정하고 싶은 `Image List`를 받아옴
  >> - addedImages : 추가할 이미지
  >> - deletedImages : 수정하고 싶은 Image Id
  > - 2. 수정할 Image 들의 `id` 를 바탕으로 NoticeImage Entity 에 있던 기존의 Image 들을 삭제
  > - 3. 변경하고 싶은 Image List 들을 NoticeImage Entity 에 저장

- 인증 🅾️
- 인가 🅾️

### 🌹 Delete
- DELETE `/api/v1/notice/{id}`
- `MASTER`나 `ADMIN`만 공지사항을 **_삭제_** 할 수 있음
- NoticeImage Entity 에 @OnDelete(action = OnDeleteAction.CASCADE) 를 적용하였으므로 Notice Entity 를 제거하면 연관된 NoticeImage Entity 도 제거됨
- 인증 🅾️
- 인가 🅾️