### PR TITLE
🦋 [MASTER] 예약 승인 거부 기능 관련 API 추가 🦋

### DIFF
--- a/src/main/kotlin/com/thepan/reservationapiserver/advice/ExceptionAdvice.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/advice/ExceptionAdvice.kt
@@ -127,4 +127,10 @@ class ExceptionAdvice {
     fun noticeNotFoundException(): ApiResponse<Unit> {
         return ApiResponse.failure(-1016, "요청하신 공지사항을 찾을 수 없습니다.");
     }
+    
+    @ExceptionHandler(ReservationNotFoundException::class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    fun reservationNotFoundException(): ApiResponse<Unit> {
+        return ApiResponse.failure(-1017, "요청하신 예약 정보를 찾을 수 없습니다.");
+    }
 }

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
@@ -55,8 +55,11 @@ class SecurityConfig(
                     .requestMatchers(HttpMethod.POST, "/api/v1/notice").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.DELETE, "/api/v1/notice/{id}").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.PUT, "/api/v1/notice/{id}").hasRole("ADMIN")
+                    .requestMatchers(HttpMethod.GET, "/api/v1/reservation/count").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.GET, "/api/v1/reservation").hasRole("MASTER")
                     .requestMatchers(HttpMethod.GET, "/api/v1/reservation/status").hasRole("MASTER")
+                    .requestMatchers(HttpMethod.GET, "/api/v1/reservation/non-auth").hasRole("MASTER")
+                    .requestMatchers(HttpMethod.PUT, "/api/v1/reservation/check-auth/{id}").hasRole("MASTER")
                     .anyRequest() // 위의 요청을 제외한 나머지 요청
                     .authenticated() // 별도의 인가는 필요하지 않지만 인증이 접근할 수 있음
             }

--- a/src/main/kotlin/com/thepan/reservationapiserver/controller/ReservationApiController.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/controller/ReservationApiController.kt
@@ -22,15 +22,20 @@ class ReservationApiController(
         request: ReservationCreateRequest
     ): ApiResponse<Unit> {
         reservationService.create(request)
-
+    
         return ApiResponse.success()
     }
-
+    
     @GetMapping("/reservation")
     @ResponseStatus(HttpStatus.OK)
     fun readAll(): ApiResponse<List<ReservationAllResponse>> =
         ApiResponse.success(reservationService.readAll())
-
+    
+    @GetMapping("/reservation/non-auth")
+    @ResponseStatus(HttpStatus.OK)
+    fun readAllNonAuth(): ApiResponse<List<ReservationAllResponse>> =
+        ApiResponse.success(reservationService.readAllNonAuth())
+    
     @GetMapping("/reservation/status")
     @ResponseStatus(HttpStatus.OK)
     fun readToCondition(
@@ -38,14 +43,14 @@ class ReservationApiController(
         condition: ReservationStatusCondition
     ): ApiResponse<List<ReservationAllResponse>> =
         ApiResponse.success(reservationService.getReservationStatus(condition))
-
+    
     @GetMapping("/reservation/seats")
     @ResponseStatus(HttpStatus.OK)
     fun readReservedSeatList(
         @Valid
         request: ReservationSeatListRequest
     ): ApiResponse<List<SeatType>> = ApiResponse.success(reservationService.getTargetReservationSeatList(request))
-
+    
     @GetMapping("/reservation/count")
     @ResponseStatus(HttpStatus.OK)
     fun countReservedClients(
@@ -53,4 +58,17 @@ class ReservationApiController(
         request: ReservationClientCountRequest
     ): ApiResponse<List<ReservationClientCountResponseInterface>> =
         ApiResponse.success(reservationService.getReservationClientCount(request))
+    
+    @PutMapping("/reservation/check-auth/{id}")
+    @ResponseStatus(HttpStatus.OK)
+    fun updateNonAuth(
+        @PathVariable
+        id: Long,
+        @Valid
+        @RequestBody
+        request: ReservationApprovalCheckRequest
+    ): ApiResponse<Unit> {
+        reservationService.updateAuthorizedReservation(id, request)
+        return ApiResponse.success()
+    }
 }

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/mapper/OjbectMapper.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/mapper/OjbectMapper.kt
@@ -37,7 +37,10 @@ fun List<Reservation>.toReservationAllResponseList(): List<ReservationAllRespons
         phoneNumber = it.phoneNumber,
         reservationDateTime = it.reservationDateTime,
         reservationCount = it.reservationCount,
-        seat = it.seat.map { s -> s.seat }
+        seats = it.seat.map { s -> s.seat }.map { seat ->
+            seat.seatType.type
+        },
+        timeType = it.timeType
     )
 }
 

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/dto/ReservationAllResponse.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/dto/ReservationAllResponse.kt
@@ -2,6 +2,7 @@ package com.thepan.reservationapiserver.domain.reservation.dto
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.thepan.reservationapiserver.domain.seat.entity.Seat
+import com.thepan.reservationapiserver.domain.seat.entity.TimeType
 import java.time.LocalDateTime
 
 data class ReservationAllResponse(
@@ -11,5 +12,6 @@ data class ReservationAllResponse(
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     val reservationDateTime: LocalDateTime,
     val reservationCount: Int,
-    val seat: List<Seat>
+    val seats: List<String>,
+    val timeType: TimeType
 )

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/dto/ReservationApprovalCheckRequest.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/dto/ReservationApprovalCheckRequest.kt
@@ -1,0 +1,5 @@
+package com.thepan.reservationapiserver.domain.reservation.dto
+
+data class ReservationApprovalCheckRequest(
+    val isApproved: Boolean
+)

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/entity/Reservation.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/entity/Reservation.kt
@@ -23,6 +23,8 @@ class Reservation(
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     var timeType: TimeType,
+    @Column(nullable = true)
+    var certificationNumber: String? = null,
     /**
      * Reservation 에서 ReservationSeat 를 관리하기 위해 설정
      * cascade = [CascadeType.ALL] 👉 부모 Entity 에 대한 변경이 자식 Entity 에 영향을 미치도록

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/repository/ReservationRepository.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/repository/ReservationRepository.kt
@@ -11,9 +11,12 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 
 interface ReservationRepository : JpaRepository<Reservation, Long> {
+    @Query("select r from Reservation r where r.certificationNumber is null")
+    fun findNonAuth(): List<Reservation>
+    
     @Query("SELECT r FROM Reservation r WHERE CAST(r.reservationDateTime AS date) = :date")
     fun findByReservationDate(date: LocalDate): List<Reservation>
-
+    
     // 📌 내 예약 정보를 가져옴
     @Query("SELECT r FROM Reservation r WHERE r.id = :reservationId AND r.timeType = :timeType AND r.reservationDateTime = :reservationDateTime")
     fun findByReservationIdAndTimeTypeAndDateTime(

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/seat/entity/TimeType.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/seat/entity/TimeType.kt
@@ -1,6 +1,7 @@
 package com.thepan.reservationapiserver.domain.seat.entity
 
 enum class TimeType(val type: String) {
-    LUNCH("점심"),
-    DINNER("저녁")
+    PART_A("13:00"),
+    PART_B("17:50"),
+    PART_C("20:00")
 }

--- a/src/main/kotlin/com/thepan/reservationapiserver/exception/ReservationNotFoundException.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/exception/ReservationNotFoundException.kt
@@ -1,0 +1,3 @@
+package com.thepan.reservationapiserver.exception
+
+class ReservationNotFoundException : RuntimeException()

--- a/src/main/kotlin/com/thepan/reservationapiserver/utils/Utils.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/utils/Utils.kt
@@ -33,3 +33,21 @@ fun makeRandomMessage(): String {
     
     return numStr
 }
+
+/**
+ * @author choi young-jun
+ * - 알파벳과 숫자(0~9)의 조합으로 16 자리 String 을 만들어 반환
+ * - 예약 인증 번호로 사용
+ */
+fun makeReservationRandomCode(): String {
+    val characters = ('a'..'z') + ('0'..'9')
+    val rand = Random()
+    var text = ""
+    
+    for (i in 0 until 16) {
+        val randomChar = characters[rand.nextInt(characters.size)]
+        text += randomChar
+    }
+    
+    return text
+}


### PR DESCRIPTION
## 🌸 예약
- 1️⃣ 사용자가 예약함
- 2️⃣  방금 예약한 사용자에게 Kakao 알림 톡을 날려서 5만원 사장 계좌에 입금하라구함
  > - 2-1) 2번과 동시에 사장한테는 Notification 을 날려서 사용자가 예약했다고 알림 
- 3️⃣ 사장이 Notification 을 클릭해서 들어감
- 4️⃣ 앱에서 승인 못받은 리스트가 보여지고 있는 화면으로 감
- 5️⃣ 그 화면에서 사장이 예약자 승인 or 거부 시켜줌
  > - 5-1) 거절된 경우 Kakao 예약 취소 알림톡 날려줘야함 
- 6️⃣ 예약자한테 예약번호와 함께 Kakao 알림을 보내서 예약이 승인된 것을 알려줌(예약 인증번호도 같이 보내기) 
- 7️⃣ 추후 예약자가 이 예약 번호를 바탕으로 예약 정보를 가져올 수 있음

### 🌹 예약 승인, 거부 판결을 받지않은 경우 (4번 작업)
- GET /api/v1/reservation/non-auth API 생성
- 해당 API는 `MASTER` 만 접근가능
- Reservation Entity 의 certificationNumber 컬럼이 null 인 Reservation Entity 를 반환

### 🌹 예약 승인 및 거부 (5번 작업)
- PUT /api/v1/reservation/check-auth/{id} API 생성
- 해당 API는 `MASTER` 만 접근가능
- Client 에서 넘어오는 `isApproved` 를 바탕으로 승인 및 거부 처리
  > ### **_📌 참고_**
  > #### ※ 승인
  > - isAprroved 가 true 인 경우 승인이 되었다고 판단
  > - PathVariable 로 넘어온 id 값으로 Reservation Entity 를 조회하고 해당 Reservation Entity 의 certificationNumber 컬럼에 16자리 랜덤 String 을 넣어줌
  >
    >> ※ 코드
    >> ``` sql
    >> select r from Reservation r where r.certificationNumber is null
    >> ```
  >
  > #### ※ 거절
  > - isAprroved 가 false 인 경우 거부되었다고 판단
  > - PathVariable 로 넘어온 id 값으로 Reservation Entity 를 조회하고 entity 를 삭제
  >
    >> ※ 코드
    >> ``` kotlin
    >> fun updateAuthorizedReservation(id: Long, request: ReservationApprovalCheckRequest) {
    >>     val reservation = reservationRepository.findById(id).orElseThrow {
    >>         ReservationNotFoundException()
    >>     }
    >> 
    >>     if (!request.isApproved) {
    >>         reservationRepository.delete(reservation)
    >>         // TODO:: 수락 취소된 경우 KAKAO 알림톡으로 알려주기
    >>         return
    >>     }
    >> }
    >> ```