### PR TITLE
특정 날짜 비승인된 예약 리스트 가져오는 API 추가

### DIFF
--- a/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
@@ -60,6 +60,7 @@ class SecurityConfig(
                     .requestMatchers(HttpMethod.GET, "/api/v1/reservation/status").hasRole("MASTER")
                     .requestMatchers(HttpMethod.GET, "/api/v1/reservation/non-auth").hasRole("MASTER")
                     .requestMatchers(HttpMethod.PUT, "/api/v1/reservation/check-auth/{id}").hasRole("MASTER")
+                    .requestMatchers(HttpMethod.GET, "/reservation/non-auth/day-time").hasRole("MASTER")
                     .anyRequest() // 위의 요청을 제외한 나머지 요청
                     .authenticated() // 별도의 인가는 필요하지 않지만 인증이 접근할 수 있음
             }

--- a/src/main/kotlin/com/thepan/reservationapiserver/controller/ReservationApiController.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/controller/ReservationApiController.kt
@@ -3,6 +3,7 @@ package com.thepan.reservationapiserver.controller
 import com.thepan.reservationapiserver.domain.base.ApiResponse
 import com.thepan.reservationapiserver.domain.reservation.ReservationService
 import com.thepan.reservationapiserver.domain.reservation.dto.*
+import com.thepan.reservationapiserver.domain.reservation.entity.Reservation
 import com.thepan.reservationapiserver.domain.seat.entity.SeatType
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
@@ -22,20 +23,20 @@ class ReservationApiController(
         request: ReservationCreateRequest
     ): ApiResponse<Unit> {
         reservationService.create(request)
-    
+
         return ApiResponse.success()
     }
-    
+
     @GetMapping("/reservation")
     @ResponseStatus(HttpStatus.OK)
     fun readAll(): ApiResponse<List<ReservationAllResponse>> =
         ApiResponse.success(reservationService.readAll())
-    
+
     @GetMapping("/reservation/non-auth")
     @ResponseStatus(HttpStatus.OK)
     fun readAllNonAuth(): ApiResponse<List<ReservationAllResponse>> =
         ApiResponse.success(reservationService.readAllNonAuth())
-    
+
     @GetMapping("/reservation/status")
     @ResponseStatus(HttpStatus.OK)
     fun readToCondition(
@@ -43,14 +44,14 @@ class ReservationApiController(
         condition: ReservationStatusCondition
     ): ApiResponse<List<ReservationAllResponse>> =
         ApiResponse.success(reservationService.getReservationStatus(condition))
-    
+
     @GetMapping("/reservation/seats")
     @ResponseStatus(HttpStatus.OK)
     fun readReservedSeatList(
         @Valid
         request: ReservationSeatListRequest
     ): ApiResponse<List<SeatType>> = ApiResponse.success(reservationService.getTargetReservationSeatList(request))
-    
+
     @GetMapping("/reservation/count")
     @ResponseStatus(HttpStatus.OK)
     fun countReservedClients(
@@ -58,7 +59,7 @@ class ReservationApiController(
         request: ReservationClientCountRequest
     ): ApiResponse<List<ReservationClientCountResponseInterface>> =
         ApiResponse.success(reservationService.getReservationClientCount(request))
-    
+
     @PutMapping("/reservation/check-auth/{id}")
     @ResponseStatus(HttpStatus.OK)
     fun updateNonAuth(
@@ -71,4 +72,9 @@ class ReservationApiController(
         reservationService.updateAuthorizedReservation(id, request)
         return ApiResponse.success()
     }
+
+    @GetMapping("/reservation/non-auth/day-time")
+    @ResponseStatus(HttpStatus.OK)
+    fun readDayAndTimeTypeNonAuth(@Valid request: ReservationNotApporveRequest): ApiResponse<List<ReservationAllResponse>> =
+        ApiResponse.success(reservationService.getReservationDayAndTimeTypeNonAuth(request))
 }

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/ReservationService.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/ReservationService.kt
@@ -4,6 +4,7 @@ import com.thepan.reservationapiserver.domain.mapper.toEntity
 import com.thepan.reservationapiserver.domain.mapper.toReservationAllResponseList
 import com.thepan.reservationapiserver.domain.mapper.toSeatTypeList
 import com.thepan.reservationapiserver.domain.reservation.dto.*
+import com.thepan.reservationapiserver.domain.reservation.entity.Reservation
 import com.thepan.reservationapiserver.domain.reservation.repository.ReservationRepository
 import com.thepan.reservationapiserver.domain.seat.entity.Seat
 import com.thepan.reservationapiserver.domain.seat.entity.SeatType
@@ -41,8 +42,9 @@ class ReservationService(
     }
 
     fun readAll(): List<ReservationAllResponse> = reservationRepository.findAll().toReservationAllResponseList()
-    
-    fun readAllNonAuth(): List<ReservationAllResponse> = reservationRepository.findNonAuth().toReservationAllResponseList()
+
+    fun readAllNonAuth(): List<ReservationAllResponse> =
+        reservationRepository.findNonAuth().toReservationAllResponseList()
 
     fun getReservationStatus(condition: ReservationStatusCondition): List<ReservationAllResponse> =
         reservationRepository.findByReservationDate(condition.dateTime.toLocalDate()).toReservationAllResponseList()
@@ -61,19 +63,19 @@ class ReservationService(
             leftReservationList.map { it.seatType }
         }
     }
-    
+
     // 📌 마스터가 예약 수락 및 거절을 눌렀을 경우
     fun updateAuthorizedReservation(id: Long, request: ReservationApprovalCheckRequest) {
         val reservation = reservationRepository.findById(id).orElseThrow {
             ReservationNotFoundException()
         }
-        
+
         if (!request.isApproved) {
             reservationRepository.delete(reservation)
             // TODO:: 수락 취소된 경우 KAKAO 알림톡으로 알려주기
             return
         }
-        
+
         reservation.certificationNumber = makeReservationRandomCode()
         reservationRepository.save(reservation)
         // TODO:: 수락 성공한 경우 KAKAO 알림톡으로 인증번호와 함께 알려주기
@@ -142,5 +144,13 @@ class ReservationService(
         request: ReservationClientCountRequest
     ): List<ReservationClientCountResponseInterface> =
         reservationRepository.findByUserNameAndPhoneNumber(request.name, request.phoneNumber)
+
+    fun getReservationDayAndTimeTypeNonAuth(
+        request: ReservationNotApporveRequest
+    ): List<ReservationAllResponse> =
+        reservationRepository.findByTimeTypeAndReservationDateTimeAndCertificationNumberIsNull(
+            request.timeType,
+            request.reservationDateTime
+        ).toReservationAllResponseList()
 
 }

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/dto/ReservationNotApporveRequest.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/dto/ReservationNotApporveRequest.kt
@@ -1,0 +1,11 @@
+package com.thepan.reservationapiserver.domain.reservation.dto
+
+import com.thepan.reservationapiserver.domain.seat.entity.TimeType
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDateTime
+
+data class ReservationNotApporveRequest (
+    @field:NotNull
+    val timeType: TimeType,
+    val reservationDateTime: LocalDateTime,
+)

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/repository/ReservationRepository.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/repository/ReservationRepository.kt
@@ -1,5 +1,6 @@
 package com.thepan.reservationapiserver.domain.reservation.repository
 
+import com.thepan.reservationapiserver.domain.reservation.dto.ReservationAllResponse
 import com.thepan.reservationapiserver.domain.reservation.dto.ReservationClientCountResponseInterface
 import com.thepan.reservationapiserver.domain.reservation.entity.Reservation
 import com.thepan.reservationapiserver.domain.reservation.entity.ReservationSeat
@@ -13,10 +14,10 @@ import java.time.LocalDateTime
 interface ReservationRepository : JpaRepository<Reservation, Long> {
     @Query("select r from Reservation r where r.certificationNumber is null")
     fun findNonAuth(): List<Reservation>
-    
+
     @Query("SELECT r FROM Reservation r WHERE CAST(r.reservationDateTime AS date) = :date")
     fun findByReservationDate(date: LocalDate): List<Reservation>
-    
+
     // 📌 내 예약 정보를 가져옴
     @Query("SELECT r FROM Reservation r WHERE r.id = :reservationId AND r.timeType = :timeType AND r.reservationDateTime = :reservationDateTime")
     fun findByReservationIdAndTimeTypeAndDateTime(
@@ -53,4 +54,12 @@ interface ReservationRepository : JpaRepository<Reservation, Long> {
         @Param("name") name: String?,
         @Param("phoneNumber") phoneNumber: String?
     ): List<ReservationClientCountResponseInterface>
+
+    /**
+     * 📌 해당 날짜, 해당 시간에 예약 승인 안되어있는 예약 List 가져오기
+     */
+    fun findByTimeTypeAndReservationDateTimeAndCertificationNumberIsNull(
+        timeType: TimeType,
+        reservationDateTime: LocalDateTime
+    ): List<Reservation>
 }


### PR DESCRIPTION
##  ✅ 특정 날짜에 비승인된 예약 리스트 가져오는 API 추가
- endPoint 👉 GET `/reservation/non-auth/day-time`
- param 👉 timeType, reservationDateTime

- 🏴 ReservationRepo.kt
```kt
1. 쿼리 어노테이션 O
+ @Query("SELECT r FROM Reservation r WHERE name :name AND reservationDateTime :reservationDateTime AND certificationNumber is Null")

2. 쿼리 어노테이션 X, JPA O
    fun findByTimeTypeAndReservationDateTimeAndCertificationNumberIsNull(
        timeType: TimeType,
        reservationDateTime: LocalDateTime
    ): List<Reservation>
```