### PR TITLE
🦋 App Main 에서 사용될 BannerImage Api 추가 🦋

### DIFF
--- a/src/main/kotlin/com/thepan/reservationapiserver/InitDB.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/InitDB.kt
@@ -1,5 +1,7 @@
 package com.thepan.reservationapiserver
 
+import com.thepan.reservationapiserver.domain.banner.entity.BannerImage
+import com.thepan.reservationapiserver.domain.banner.repository.BannerImageRepository
 import com.thepan.reservationapiserver.domain.member.entity.Member
 import com.thepan.reservationapiserver.domain.member.entity.RoleType
 import com.thepan.reservationapiserver.domain.member.repository.MemberRepository
@@ -18,7 +20,8 @@ import org.springframework.transaction.annotation.Transactional
 class InitDB(
     private val memberRepository: MemberRepository,
     private val roleRepository: RoleRepository,
-    private val bCryptPasswordEncoder: BCryptPasswordEncoder
+    private val bCryptPasswordEncoder: BCryptPasswordEncoder,
+    private val bannerImageRepository: BannerImageRepository
 ) {
     private val log = KotlinLogging.logger {}
     
@@ -27,6 +30,7 @@ class InitDB(
     fun initDb() {
         log.info("🌹 initDB Called 🌹")
         initAdminAndMasterUser()
+        initBannerImage()
     }
     
     private fun initAdminAndMasterUser() {
@@ -56,5 +60,24 @@ class InitDB(
         adminMasterList.add(master)
         
         memberRepository.saveAll(adminMasterList)
+    }
+    
+    private fun initBannerImage() {
+        val bannerImageList = ArrayList<BannerImage>()
+        
+        val bannerImage1 = BannerImage(uniqueName = "", originName = "IMG_9559.JPG")
+        bannerImage1.uniqueName = "deadbbca-36cc-470a-a4f5-c0175c654a62.JPG"
+        
+        val bannerImage2 = BannerImage(uniqueName = "", originName = "IMG_9561.JPG")
+        bannerImage2.uniqueName = "d34db6cc-9ebc-407e-b7aa-1ebef7b2d148.JPG"
+        
+        val bannerImage3 = BannerImage(uniqueName = "", originName = "IMG_9557.JPG")
+        bannerImage3.uniqueName = "8e18e30e-519f-41b4-8b42-aba48b0c1def.JPG"
+    
+        bannerImageList.add(bannerImage1)
+        bannerImageList.add(bannerImage2)
+        bannerImageList.add(bannerImage3)
+        
+        bannerImageRepository.saveAll(bannerImageList)
     }
 }

--- a/src/main/kotlin/com/thepan/reservationapiserver/advice/ExceptionAdvice.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/advice/ExceptionAdvice.kt
@@ -9,6 +9,7 @@ import org.springframework.validation.BindException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.multipart.MultipartException
 
 @RestControllerAdvice
 class ExceptionAdvice {
@@ -132,5 +133,18 @@ class ExceptionAdvice {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     fun reservationNotFoundException(): ApiResponse<Unit> {
         return ApiResponse.failure(-1017, "요청하신 예약 정보를 찾을 수 없습니다.");
+    }
+    
+    @ExceptionHandler(BannerImageNotFoundException::class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    fun bannerImageNotFoundException(): ApiResponse<Unit> {
+        return ApiResponse.failure(-1018, "요청하신 배너 이미지를 찾을 수 없습니다.")
+    }
+    
+    // 📌 Multipart Upload 시 용량초과 Exception
+    @ExceptionHandler(MultipartException::class)
+    @ResponseStatus(HttpStatus.PAYLOAD_TOO_LARGE)
+    fun multipartException(): ApiResponse<Unit> {
+        return ApiResponse.failure(-1019, "파일 용량초과, 요청하신 파일이 너무 큽니다.")
     }
 }

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
@@ -52,6 +52,7 @@ class SecurityConfig(
                 ).permitAll()
                     .requestMatchers(HttpMethod.GET, "/image/**").permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/v1/reservation").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/v1/banner/images").permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/v1/notice").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.DELETE, "/api/v1/notice/{id}").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.PUT, "/api/v1/notice/{id}").hasRole("ADMIN")
@@ -60,7 +61,9 @@ class SecurityConfig(
                     .requestMatchers(HttpMethod.GET, "/api/v1/reservation/status").hasRole("MASTER")
                     .requestMatchers(HttpMethod.GET, "/api/v1/reservation/non-auth").hasRole("MASTER")
                     .requestMatchers(HttpMethod.PUT, "/api/v1/reservation/check-auth/{id}").hasRole("MASTER")
-                    .requestMatchers(HttpMethod.GET, "/reservation/non-auth/day-time").hasRole("MASTER")
+                    .requestMatchers(HttpMethod.GET, "/api/v1/reservation/non-auth/day-time").hasRole("MASTER")
+                    .requestMatchers(HttpMethod.POST, "/api/v1/banner/images").hasRole("MASTER")
+                    .requestMatchers(HttpMethod.DELETE, "/api/v1/banner/images/{id}").hasRole("MASTER")
                     .anyRequest() // 위의 요청을 제외한 나머지 요청
                     .authenticated() // 별도의 인가는 필요하지 않지만 인증이 접근할 수 있음
             }

--- a/src/main/kotlin/com/thepan/reservationapiserver/controller/BannerImageApiController.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/controller/BannerImageApiController.kt
@@ -1,0 +1,42 @@
+package com.thepan.reservationapiserver.controller
+
+import com.thepan.reservationapiserver.domain.banner.dto.BannerImageAllResponse
+import com.thepan.reservationapiserver.domain.banner.dto.BannerImageCreateRequest
+import com.thepan.reservationapiserver.domain.banner.service.BannerImageService
+import com.thepan.reservationapiserver.domain.base.ApiResponse
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1")
+class BannerImageApiController(
+    private val bannerImageService: BannerImageService
+) {
+    
+    @PostMapping("/banner/images")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun save(
+        @Valid
+        @ModelAttribute
+        request: BannerImageCreateRequest
+    ): ApiResponse<Unit> {
+        bannerImageService.create(request)
+        return ApiResponse.success()
+    }
+    
+    @GetMapping("/banner/images")
+    @ResponseStatus(HttpStatus.OK)
+    fun readAll(): ApiResponse<List<BannerImageAllResponse>> =
+        ApiResponse.success(bannerImageService.readAll())
+    
+    @DeleteMapping("banner/images/{id}")
+    @ResponseStatus(HttpStatus.OK)
+    fun delete(
+        @PathVariable
+        id: Long
+    ): ApiResponse<Unit> {
+        bannerImageService.delete(id)
+        return ApiResponse.success()
+    }
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/banner/dto/BannerImageAllResponse.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/banner/dto/BannerImageAllResponse.kt
@@ -1,0 +1,6 @@
+package com.thepan.reservationapiserver.domain.banner.dto
+
+data class BannerImageAllResponse(
+    val id: Long?,
+    val images: String
+)

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/banner/dto/BannerImageCreateRequest.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/banner/dto/BannerImageCreateRequest.kt
@@ -1,0 +1,11 @@
+package com.thepan.reservationapiserver.domain.banner.dto
+
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+import org.springframework.web.multipart.MultipartFile
+
+data class BannerImageCreateRequest(
+    @field:NotNull(message = "배너 이미지는 Null 일 수 없습니다.")
+    @field:Size(min = 1, message = "배너 이미지는 최소하나 이상으로 하셔야합니다.")
+    val images: List<MultipartFile>
+)

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/banner/entity/BannerImage.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/banner/entity/BannerImage.kt
@@ -1,14 +1,12 @@
-package com.thepan.reservationapiserver.domain.notice.entity
+package com.thepan.reservationapiserver.domain.banner.entity
 
 import com.thepan.reservationapiserver.domain.base.BaseEntity
 import com.thepan.reservationapiserver.utils.extractExtension
 import com.thepan.reservationapiserver.utils.generateUniqueName
 import jakarta.persistence.*
-import org.hibernate.annotations.OnDelete
-import org.hibernate.annotations.OnDeleteAction
 
 @Entity
-class NoticeImage(
+class BannerImage(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null,
@@ -16,19 +14,8 @@ class NoticeImage(
     var uniqueName: String,
     @Column(nullable = false)
     var originName: String,
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "noticeId")
-    @OnDelete(action = OnDeleteAction.CASCADE)
-    var notice: Notice? = null
 ) : BaseEntity() {
     init {
         this.uniqueName = generateUniqueName(extractExtension(originName))
-    }
-    
-    // Notice 의 연관 관계에 대한 정보가 없다면 이를 등록
-    fun initNotice(notice: Notice) {
-        if (this.notice == null) {
-            this.notice = notice
-        }
     }
 }

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/banner/repository/BannerImageRepository.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/banner/repository/BannerImageRepository.kt
@@ -1,0 +1,10 @@
+package com.thepan.reservationapiserver.domain.banner.repository
+
+import com.thepan.reservationapiserver.domain.banner.entity.BannerImage
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface BannerImageRepository : JpaRepository<BannerImage, Long> {
+    @Query("SELECT b FROM BannerImage b ORDER BY b.modifiedAt DESC")
+    fun findLatestModifiedBanner(): List<BannerImage>
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/banner/service/BannerImageService.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/banner/service/BannerImageService.kt
@@ -1,0 +1,55 @@
+package com.thepan.reservationapiserver.domain.banner.service
+
+import com.thepan.reservationapiserver.domain.banner.dto.BannerImageAllResponse
+import com.thepan.reservationapiserver.domain.banner.dto.BannerImageCreateRequest
+import com.thepan.reservationapiserver.domain.banner.entity.BannerImage
+import com.thepan.reservationapiserver.domain.banner.repository.BannerImageRepository
+import com.thepan.reservationapiserver.domain.file.FileService
+import com.thepan.reservationapiserver.domain.mapper.toBannerImageAllResponse
+import com.thepan.reservationapiserver.exception.BannerImageNotFoundException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.multipart.MultipartFile
+
+@Service
+class BannerImageService(
+    private val bannerImageRepository: BannerImageRepository,
+    private val fileService: FileService
+) {
+    @Transactional
+    fun create(request: BannerImageCreateRequest) {
+        val bannerImageList = request.images.map {
+            BannerImage(uniqueName = "", originName = it.originalFilename!!)
+        }
+        
+        val savedBannerImageList = bannerImageRepository.saveAll(bannerImageList)
+        uploadImage(savedBannerImageList, request.images)
+    }
+    
+    fun readAll(): List<BannerImageAllResponse> = bannerImageRepository.findLatestModifiedBanner().toBannerImageAllResponse()
+    
+    @Transactional
+    fun delete(id: Long) {
+        val bannerImage = getBannerImageFindById(id)
+        
+        deleteImage(bannerImage)
+        bannerImageRepository.delete(bannerImage)
+    }
+    
+    private fun getBannerImageFindById(id: Long): BannerImage = bannerImageRepository.findById(id).orElseThrow {
+        BannerImageNotFoundException()
+    }
+    
+    private fun uploadImage(
+        images: List<BannerImage>,
+        fileImages: List<MultipartFile>
+    ) {
+        images.indices.forEachIndexed { index, _ ->
+            fileService.upload(fileImages[index], images[index].uniqueName)
+        }
+    }
+    
+    private fun deleteImage(image: BannerImage) {
+        fileService.delete(image.uniqueName)
+    }
+}

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/mapper/OjbectMapper.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/mapper/OjbectMapper.kt
@@ -1,6 +1,8 @@
 package com.thepan.reservationapiserver.domain.mapper
 
 import com.thepan.reservationapiserver.config.security.CustomUserDetails
+import com.thepan.reservationapiserver.domain.banner.dto.BannerImageAllResponse
+import com.thepan.reservationapiserver.domain.banner.entity.BannerImage
 import com.thepan.reservationapiserver.domain.member.dto.MyMemberInfoResponse
 import com.thepan.reservationapiserver.domain.member.entity.Member
 import com.thepan.reservationapiserver.domain.member.entity.MemberRole
@@ -129,4 +131,8 @@ private fun List<NoticeImage>.toNoticeImageResponseList(): List<NoticeImageRespo
         originName = it.originName,
         uniqueName = it.uniqueName
     )
+}
+
+fun List<BannerImage>.toBannerImageAllResponse(): List<BannerImageAllResponse> = map {
+    BannerImageAllResponse(it.id, it.uniqueName)
 }

--- a/src/main/kotlin/com/thepan/reservationapiserver/exception/BannerImageNotFoundException.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/exception/BannerImageNotFoundException.kt
@@ -1,0 +1,3 @@
+package com.thepan.reservationapiserver.exception
+
+class BannerImageNotFoundException : RuntimeException()

--- a/src/main/kotlin/com/thepan/reservationapiserver/utils/Utils.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/utils/Utils.kt
@@ -1,6 +1,7 @@
 package com.thepan.reservationapiserver.utils
 
-import java.util.Random
+import com.thepan.reservationapiserver.exception.UnsupportedImageFormatException
+import java.util.*
 
 /**
  * @author choi young-jun
@@ -51,3 +52,26 @@ fun makeReservationRandomCode(): String {
     
     return text
 }
+
+fun generateUniqueName(extension: String): String = UUID.randomUUID().toString() + "." + extension
+
+// 이미지 이름에서 확장자를 추출
+fun extractExtension(originName: String): String {
+    try {
+        val ext = originName.substring(originName.lastIndexOf(".") + 1)
+        if (isSupportedFormat(ext))
+            return ext
+    } catch (e: StringIndexOutOfBoundsException) {
+        throw UnsupportedImageFormatException()
+    }
+    
+    throw UnsupportedImageFormatException()
+}
+
+// 지원하는 확장자인지 확인
+private fun isSupportedFormat(ext: String): Boolean = supportedExtension.any {
+    it.equals(ext, ignoreCase = true)
+}
+
+// 해당 이미지가 지원하는 이미지 확장자
+private val supportedExtension = arrayOf("jpg", "jpeg", "gif", "bmp", "png")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,8 +22,8 @@ spring:
       host: localhost
       port: 6379
 
-  servlet.multipart.max-file-size: 5MB
-  servlet.multipart.max-request-size: 5MB
+  servlet.multipart.max-file-size: 20MB
+  servlet.multipart.max-request-size: 25MB
 
 jwt:
   issuer: narvis2@naver.com


### PR DESCRIPTION
## 🌸 BannerImage
- BannerImage Entity 는 일단 어떤 곳에도 연관되지않고 존재하는 독립적인 Entity 임

### 🌹 생성
- POST /api/v1/banner/images
- MASTER 권한을 가진 유저만 해당 API 접근 가능
- 인증 🅾️
- 인가 🅾️

### 🌹 가져오기
- GET /api/v1/banner/images
- 모든 유저들이 접근할 수 있음
- 인증 ❌
- 인가 ❌

### 🌹 삭제
- DELETE /api/v1/banner/images/{id}
- MASTER 권한을 가진 유저만 해당 API 접근 가능
- 인증 🅾️
- 인가 🅾️

### 🌹 ExceptionAdvice
- 파일 용량 초과 Exception 추가
  > ``` kotlin
  > @ExceptionHandler(MultipartException::class)
  > @ResponseStatus(HttpStatus.PAYLOAD_TOO_LARGE)
  > fun multipartException(): ApiResponse<Unit> {
  >     return ApiResponse.failure(-1019, "파일 용량초과, 요청하신 파일이 너무 큽니다.")
  > }
  > ```

- BannerImage 를 찾을 수 없는 경우 Exception 추가
  > ``` kotlin
  > @ExceptionHandler(BannerImageNotFoundException::class)
  > @ResponseStatus(HttpStatus.NOT_FOUND)
  > fun bannerImageNotFoundException(): ApiResponse<Unit> {
  >     return ApiResponse.failure(-1018, "요청하신 배너 이미지를 찾을 수 없습니다.")
  > }
  > ```

### 🌹 application.yml
- 파일 용량 설정 변경
  > **_참고_**
  > -
  > ※ 수정전
  > ``` yml
  > servlet.multipart.max-file-size: 5MB
  > servlet.multipart.max-request-size: 5MB
  > ```
  > ※ 수정후
  > ``` yml
  > servlet.multipart.max-file-size: 20MB
  > servlet.multipart.max-request-size: 25MB
  > ```