### PR TITLE
🦋 PartTime을 신경쓰지 않고 특정 날짜의 남아있는 좌석을 가져오는 API 추가 🦋

### DIFF
--- a/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
@@ -47,7 +47,7 @@ class SecurityConfig(
                 auth.requestMatchers(
                     "/api/v1/sign/**",
                     "/api/v1/seats/**",
-                    "/api/v1/reservation/seats",
+                    "/api/v1/reservation/seats/**",
                     "/api/v1/notices"
                 ).permitAll()
                     .requestMatchers(HttpMethod.GET, "/image/**").permitAll()

--- a/src/main/kotlin/com/thepan/reservationapiserver/controller/ReservationApiController.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/controller/ReservationApiController.kt
@@ -44,6 +44,13 @@ class ReservationApiController(
         condition: ReservationStatusCondition
     ): ApiResponse<List<ReservationAllResponse>> =
         ApiResponse.success(reservationService.getReservationStatus(condition))
+    
+    @GetMapping("/reservation/seats/date")
+    fun readReservedDateSeatList(
+        @Valid
+        condition: ReservationTargetDateRequest
+    ): ApiResponse<List<ReservationTargetDateResponse>> =
+        ApiResponse.success(reservationService.getTargetDateReservationSeatList(condition))
 
     @GetMapping("/reservation/seats")
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/ReservationService.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/ReservationService.kt
@@ -43,13 +43,29 @@ class ReservationService(
 
     fun readAll(): List<ReservationAllResponse> = reservationRepository.findAll().toReservationAllResponseList()
 
+    // 📌 비승인된 예약 리스트 가져오기
     fun readAllNonAuth(): List<ReservationAllResponse> =
         reservationRepository.findNonAuth().toReservationAllResponseList()
 
     fun getReservationStatus(condition: ReservationStatusCondition): List<ReservationAllResponse> =
         reservationRepository.findByReservationDate(condition.dateTime.toLocalDate()).toReservationAllResponseList()
+    
+    // 📌 PartTime 을 신경쓰지않고 특정 날짜의 남아있는 좌석을 PartTime 별로 분류하여 List 로 가져옴
+    fun getTargetDateReservationSeatList(condition: ReservationTargetDateRequest): List<ReservationTargetDateResponse> {
+        val reservationDateList: ArrayList<ReservationTargetDateResponse> = ArrayList()
+    
+        TimeType.values().forEach { timeType ->
+            val targetSeatList = getTargetReservationSeatList(
+                ReservationSeatListRequest(timeType.name, condition.findDate)
+            )
+            
+            reservationDateList.add(ReservationTargetDateResponse(timeType, targetSeatList))
+        }
+        
+        return reservationDateList
+    }
 
-    // 📌 특정 날짜에 남아있는 좌석 List 가져오기
+    // 📌 특정 날짜의 PartTime 에 남아있는 좌석 List 가져오기
     fun getTargetReservationSeatList(request: ReservationSeatListRequest): List<SeatType> {
         val reservedSeatList = getReservationInfoList(request.timeType, request.reservationDateTime)
         val allSeatList = seatRepository.findAll()
@@ -140,11 +156,13 @@ class ReservationService(
 
     private fun stringToTimeType(timeType: String): TimeType = TimeType.valueOf(timeType)
 
+    // 📌 특정 손님의 예약 횟수 목록 가져오기
     fun getReservationClientCount(
         request: ReservationClientCountRequest
     ): List<ReservationClientCountResponseInterface> =
         reservationRepository.findByUserNameAndPhoneNumber(request.name, request.phoneNumber)
 
+    //📌 특정 날짜에 비승인된 예약 리스트 가져오기
     fun getReservationDayAndTimeTypeNonAuth(
         request: ReservationNotApporveRequest
     ): List<ReservationAllResponse> =
@@ -152,5 +170,4 @@ class ReservationService(
             request.timeType,
             request.reservationDateTime
         ).toReservationAllResponseList()
-
 }

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/dto/ReservationTargetDateRequest.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/dto/ReservationTargetDateRequest.kt
@@ -1,0 +1,11 @@
+package com.thepan.reservationapiserver.domain.reservation.dto
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDateTime
+
+data class ReservationTargetDateRequest(
+    @field:NotNull
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    val findDate: LocalDateTime
+)

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/dto/ReservationTargetDateResponse.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/dto/ReservationTargetDateResponse.kt
@@ -1,0 +1,9 @@
+package com.thepan.reservationapiserver.domain.reservation.dto
+
+import com.thepan.reservationapiserver.domain.seat.entity.SeatType
+import com.thepan.reservationapiserver.domain.seat.entity.TimeType
+
+data class ReservationTargetDateResponse(
+    val partTime: TimeType,
+    val remainsSeatList: List<SeatType>
+)


### PR DESCRIPTION
## 🌸 App의 Main 화면에 보여줄 예약관련 API 추가
- `/reservation/seats/date` API 추가
- PartTime 을 신경쓰지 않고, **_특정 날짜에 남아있는 좌석을 PartTime 별로_** 가져오는 API 추가
- 인증 ❌, 인가 ❌  즉, **_누구나 해당 API에 접근할 수 있음_**

> **_참고_**
> -
> ※ Request
> ```
> api/v1/reservation/seats/date?findDate=2023-06-28T15:00:00
> ```
>
> ※ Response
> ``` json
>{
>    "success": true,
>    "data": [
>        {
>            "partTime": "PART_A",
>            "remainsSeatList": [
>                "A_1",
>                "A_2",
>                "A_3",
>                "A_4",
>                "A_5",
>                "A_6",
>                "A_7",
>                "A_8",
>                "B",
>                "C"
>            ]
>        },
>        {
>            "partTime": "PART_B",
>            "remainsSeatList": [
>                "A_1",
>                "A_2",
>                "A_3",
>                "A_4",
>                "A_5",
>                "A_6",
>                "A_7",
>                "A_8",
>                "C"
>            ]
>        },
>        {
>            "partTime": "PART_C",
>            "remainsSeatList": [
>                "A_1",
>                "A_2",
>                "A_3",
>                "A_4",
>                "A_5",
>                "A_6",
>                "A_7",
>                "A_8",
>                "B",
>                "C"
>            ]
>        }
>    ],
>    "resultMsg": "응답 성공",
>    "code": 200
>}
> ```