### PR TITLE
🦋 로그아웃 API 인가 적용 및 로직 수정 🦋

### DIFF
--- a/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
@@ -45,7 +45,9 @@ class SecurityConfig(
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests { auth -> // 인증, 인가 설정
                 auth.requestMatchers(
-                    "/api/v1/sign/**",
+                    "/api/v1/sign/signIn",
+                    "/api/v1/sign/phone",
+                    "/api/v1/sign/phone/check",
                     "/api/v1/seats/**",
                     "/api/v1/reservation/seats/**",
                     "/api/v1/notices"

--- a/src/main/kotlin/com/thepan/reservationapiserver/controller/SignApiController.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/controller/SignApiController.kt
@@ -1,10 +1,8 @@
 package com.thepan.reservationapiserver.controller
 
-import com.thepan.reservationapiserver.config.jwt.JwtTokenHelper.Companion.HEADER_AUTHORIZATION
 import com.thepan.reservationapiserver.domain.base.ApiResponse
 import com.thepan.reservationapiserver.domain.sign.dto.*
 import com.thepan.reservationapiserver.domain.sign.service.SignService
-import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
@@ -25,10 +23,9 @@ class SignApiController(
     @PostMapping("/signOut")
     @ResponseStatus(HttpStatus.OK)
     fun signOut(
-        httpServletRequest: HttpServletRequest
+        @RequestHeader("Authorization") authorizationHeader: String
     ): ApiResponse<Unit> {
-        val accessToken = httpServletRequest.getHeader(HEADER_AUTHORIZATION)
-        signService.signOut(accessToken)
+        signService.signOut(authorizationHeader)
         return ApiResponse.success()
     }
     

--- a/src/main/kotlin/com/thepan/reservationapiserver/controller/SignApiController.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/controller/SignApiController.kt
@@ -1,8 +1,10 @@
 package com.thepan.reservationapiserver.controller
 
+import com.thepan.reservationapiserver.config.jwt.JwtTokenHelper.Companion.HEADER_AUTHORIZATION
 import com.thepan.reservationapiserver.domain.base.ApiResponse
 import com.thepan.reservationapiserver.domain.sign.dto.*
 import com.thepan.reservationapiserver.domain.sign.service.SignService
+import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
@@ -23,11 +25,10 @@ class SignApiController(
     @PostMapping("/signOut")
     @ResponseStatus(HttpStatus.OK)
     fun signOut(
-        @Valid
-        @RequestBody
-        request: SignOutRequest
+        httpServletRequest: HttpServletRequest
     ): ApiResponse<Unit> {
-        signService.signOut(request)
+        val accessToken = httpServletRequest.getHeader(HEADER_AUTHORIZATION)
+        signService.signOut(accessToken)
         return ApiResponse.success()
     }
     

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/dto/SignOutRequest.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/dto/SignOutRequest.kt
@@ -1,8 +1,0 @@
-package com.thepan.reservationapiserver.domain.sign.dto
-
-import jakarta.validation.constraints.NotBlank
-
-data class SignOutRequest(
-    @field:NotBlank(message = "accessToken 이 존재하지 않습니다.")
-    val accessToken: String
-)

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/service/SignService.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/service/SignService.kt
@@ -64,7 +64,8 @@ class SignService(
     
         // 해당 Access Token 유효시간을 가지고 와서 BlackList 에 저장
         val expiration = jwtTokenService.getAccessTokenExpiresTime()
-        redisTemplate.opsForValue().set(accessToken, "logout", expiration, TimeUnit.MILLISECONDS)
+        val removeBearerToken = jwtTokenService.removeBearerPrefix(accessToken)
+        redisTemplate.opsForValue().set(removeBearerToken, "logout", expiration, TimeUnit.MILLISECONDS)
     }
     
     fun sendMobileVerificationCode(request: PhoneAuthRequest) {

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/service/SignService.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/service/SignService.kt
@@ -1,6 +1,5 @@
 package com.thepan.reservationapiserver.domain.sign.service
 
-import com.thepan.reservationapiserver.config.jwt.JwtTokenHelper
 import com.thepan.reservationapiserver.config.jwt.JwtTokenService
 import com.thepan.reservationapiserver.domain.member.entity.Member
 import com.thepan.reservationapiserver.domain.member.repository.MemberRepository
@@ -42,14 +41,14 @@ class SignService(
     }
     
     @Transactional(readOnly = true)
-    fun signOut(request: SignOutRequest) {
+    fun signOut(accessToken: String) {
         // Token 유효성 검사
-        if (!jwtTokenService.validateAccessToken(JwtTokenHelper.TYPE + request.accessToken)) {
+        if (!jwtTokenService.validateAccessToken(accessToken)) {
             throw AuthenticationEntryPointException()
         }
         
         // Token 에서 subject 추출
-        val memberId = jwtTokenService.extractAccessTokenSubject(JwtTokenHelper.TYPE + request.accessToken)
+        val memberId = jwtTokenService.extractAccessTokenSubject(accessToken)
         
         // 추출한 subject 를 바탕으로 Member 조회
         val member = memberRepository.findById(
@@ -65,7 +64,7 @@ class SignService(
     
         // 해당 Access Token 유효시간을 가지고 와서 BlackList 에 저장
         val expiration = jwtTokenService.getAccessTokenExpiresTime()
-        redisTemplate.opsForValue().set(request.accessToken, "logout", expiration, TimeUnit.MILLISECONDS)
+        redisTemplate.opsForValue().set(accessToken, "logout", expiration, TimeUnit.MILLISECONDS)
     }
     
     fun sendMobileVerificationCode(request: PhoneAuthRequest) {


### PR DESCRIPTION
## 🌸 로그아웃 기능 수정
- 기존에 `/sign/signOut` API에 **_인증_** 적용
- `/sign/signOut` EndPoint 가 **_인증_** API가 되었으므로 더 이상 `RequestBody`로 `accessToken`을 가져올 필요가 없이 `Header` 에서 넘어오는 `Token`을 추출하여 사용할 수 있도록 수정
  > - SignOutRequest 는 이제 불필요 하므로 제거