### PR TITLE
🦋 /member/fcm-token API 용도 수정 🦋

### DIFF
--- a/src/main/kotlin/com/thepan/reservationapiserver/controller/MemberApiController.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/controller/MemberApiController.kt
@@ -4,14 +4,8 @@ import com.thepan.reservationapiserver.domain.base.ApiResponse
 import com.thepan.reservationapiserver.domain.member.dto.MemberUpdateFcmTokenRequest
 import com.thepan.reservationapiserver.domain.member.dto.MyMemberInfoResponse
 import com.thepan.reservationapiserver.domain.member.service.MemberService
-import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1")
@@ -27,7 +21,6 @@ class MemberApiController(
     @PutMapping("/member/fcm-token")
     @ResponseStatus(HttpStatus.OK)
     fun updateFcmToken(
-        @Valid
         @RequestBody
         request: MemberUpdateFcmTokenRequest
     ): ApiResponse<Unit> {

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/member/dto/MemberUpdateFcmTokenRequest.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/member/dto/MemberUpdateFcmTokenRequest.kt
@@ -1,8 +1,5 @@
 package com.thepan.reservationapiserver.domain.member.dto
 
-import jakarta.validation.constraints.NotBlank
-
 data class MemberUpdateFcmTokenRequest(
-    @field: NotBlank(message = "Firebase Cloud Message Token 을 입력해주세요.")
-    val fcmToken: String
+    val fcmToken: String? // 로그아웃하면 null 을 넣어줘야하기 때문에 null 허용
 )


### PR DESCRIPTION
## 🌸 FcmToken Update API 용도 수정
- 기존 : `@RequestBody`의 fcmToken 에 null을 허용하지 않음
- 수정 : 로그아웃 시 `fcmToken`을 다시 null 처리 해야하므로 null 허용