### PR TITLE
Maria db setting

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
     // Firebase
     implementation("com.google.firebase:firebase-admin:9.2.0")
     
-    runtimeOnly("com.h2database:h2")
+    runtimeOnly("org.mariadb.jdbc:mariadb-java-client")
     
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")

--- a/src/main/kotlin/com/thepan/reservationapiserver/InitDB.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/InitDB.kt
@@ -32,9 +32,9 @@ class InitDB(
     @EventListener(ApplicationReadyEvent::class)
     @Transactional
     fun initDb() {
-        log.info("🌹 initDB Called 🌹")
-        initAdminAndMasterUser()
-        initBannerImage()
+//        log.info("🌹 initDB Called 🌹")
+//        initAdminAndMasterUser()
+//        initBannerImage()
     }
 
     private fun initAdminAndMasterUser() {

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/RedisRepositoryConfig.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/RedisRepositoryConfig.kt
@@ -22,8 +22,13 @@ class RedisRepositoryConfig(
      * - RedisProperties 로 application.yml 에 저장한 host, post를 가지고 와서 연결
      */
     @Bean
-    fun redisConnectionFactory(): RedisConnectionFactory =
-        LettuceConnectionFactory(redisProperties.host, redisProperties.port)
+    fun redisConnectionFactory(): RedisConnectionFactory {
+        val lettuceConnectionFactory = LettuceConnectionFactory(redisProperties.host, redisProperties.port)
+        lettuceConnectionFactory.setPassword("1324")
+
+        return lettuceConnectionFactory
+    }
+
     
     
     // setKeySerializer, setValueSerializer 설정으로 redis-cli를 통해 직접 데이터를 보는게 가능

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
@@ -32,8 +32,8 @@ class SecurityConfig(
     fun webSecurityCustomizer(): WebSecurityCustomizer {
         return WebSecurityCustomizer {
             it.ignoring()
-                .requestMatchers(AntPathRequestMatcher("/h2-console/**"))
                 .requestMatchers(AntPathRequestMatcher("/exception/**"))
+//                .requestMatchers(AntPathRequestMatcher("/h2-console/**"))
         }
     }
     

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,23 +4,31 @@ spring:
     include: secret
   jpa:
     show-sql: true
+    hibernate:
+      ddl-auto: validate
     properties:
       hibernate:
+        dialect: org.hibernate.dialect.MariaDBDialect
         format_sql: true
-    defer-datasource-initialization: true
+#    defer-datasource-initialization: true
   datasource:
-    url: jdbc:h2:mem:testreservation
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
+    url: jdbc:mariadb://svc.sel4.cloudtype.app:31805/reservation
+    username: root
+    password: 1234
+    driver-class-name: org.mariadb.jdbc.Driver
+#    h2 설정
+#    url: jdbc:h2:mem:testreservation
+#    username: sa
+#    password:
+#    driver-class-name: org.h2.Driver
+#  h2:
+#    console:
+#      enabled: true
+#      path: /h2-console
   data:
     redis:
-      host: localhost
-      port: 6379
+      host: svc.sel3.cloudtype.app
+      port: 31076
 
   servlet.multipart.max-file-size: 20MB
   servlet.multipart.max-request-size: 25MB


### PR DESCRIPTION
1️⃣ build.gradle 설정에서 DB를 h2 👉 maria로 변경
>
```kotlin
runtimeOnly("com.h2database:h2") => runtimeOnly("org.mariadb.jdbc:mariadb-java-client") 
```
>

2️⃣ application.yml maria db 설정 및 redis host 수정
>
```yml
    hibernate:
      ddl-auto: validate
     // DB초기화가 필요없기때문에 create => validate 으로 옵션 변경
    properties:
      hibernate:
        dialect: org.hibernate.dialect.MariaDBDialect
        format_sql: true
        defer-datasource-initialization: true => 주석처리 
    url: jdbc:mariadb://svc.sel4.cloudtype.app:31805/reservation
    // url : jdbc:mariadb://host이름:포트번호/Database이름
    username: root
    password: 1234
    driver-class-name: org.mariadb.jdbc.Driver
    redis:
      host: svc.sel3.cloudtype.app
      port: 31076
```
>

3️⃣ redis 서버 비밀번호 추가했기때문에 비밀번호 추가하고 레디스 객체 넘기도록 수정
>
```kotlin
        val lettuceConnectionFactory = LettuceConnectionFactory(redisProperties.host, redisProperties.port)
        lettuceConnectionFactory.setPassword("1324")

        return lettuceConnectionFactory
```
>
