### PR TITLE
🦋 예약 정보 상세보기 API 추가 🦋

### DIFF
--- a/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
@@ -50,13 +50,15 @@ class SecurityConfig(
                     "/api/v1/sign/phone/check",
                     "/api/v1/seats/**",
                     "/api/v1/reservation/seats/**",
-                    "/api/v1/notices"
+                    "/api/v1/notices",
+                    "/api/v1/reservation/user"
                 ).permitAll()
                     .requestMatchers(HttpMethod.GET, "/image/**").permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/v1/reservation").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/v1/banner/images").permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/v1/reservation/filter").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.PUT, "/api/v1/reservation/check-auth/{id}").hasRole("ADMIN")
+                    .requestMatchers(HttpMethod.GET, "/api/v1/reservation/{id}").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.POST, "/api/v1/notice").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.DELETE, "/api/v1/notice/{id}").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.PUT, "/api/v1/notice/{id}").hasRole("ADMIN")

--- a/src/main/kotlin/com/thepan/reservationapiserver/controller/ReservationApiController.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/controller/ReservationApiController.kt
@@ -27,6 +27,17 @@ class ReservationApiController(
 
         return ApiResponse.success()
     }
+    
+    @GetMapping("/reservation/{id}")
+    fun read(
+        @PathVariable id: Long
+    ): ApiResponse<ReservationDetailResponse> = ApiResponse.success(reservationService.read(id))
+    
+    @GetMapping("/reservation/user")
+    fun readByUser(
+        @Valid
+        request: ReservationDetailByUserRequest
+    ): ApiResponse<ReservationDetailResponse> = ApiResponse.success(reservationService.readByUser(request))
 
     @GetMapping("/reservation")
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/mapper/OjbectMapper.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/mapper/OjbectMapper.kt
@@ -14,6 +14,7 @@ import com.thepan.reservationapiserver.domain.notice.entity.Notice
 import com.thepan.reservationapiserver.domain.notice.entity.NoticeImage
 import com.thepan.reservationapiserver.domain.reservation.dto.ReservationAllResponse
 import com.thepan.reservationapiserver.domain.reservation.dto.ReservationCreateRequest
+import com.thepan.reservationapiserver.domain.reservation.dto.ReservationDetailResponse
 import com.thepan.reservationapiserver.domain.reservation.dto.page.ReservationConditionResponse
 import com.thepan.reservationapiserver.domain.reservation.dto.page.ReservationListResponse
 import com.thepan.reservationapiserver.domain.reservation.entity.Reservation
@@ -36,6 +37,20 @@ fun ReservationCreateRequest.toEntity(seats: List<Seat>): Reservation = Reservat
     isUserValidation = this.isUserValidation,
     fcmToken = this.fcmToken,
     timeType = TimeType.valueOf(this.timeType)
+)
+
+fun Reservation.toReservationDetailResponse(): ReservationDetailResponse = ReservationDetailResponse(
+    id = this.id,
+    name = this.name,
+    phoneNumber = this.phoneNumber,
+    reservationDateTime = this.reservationDateTime,
+    reservationCount = this.reservationCount,
+    isTermAllAgree = this.isTermAllAgree,
+    isUserValidation = this.isUserValidation,
+    certificationNumber = this.certificationNumber,
+    seats = this.seat.map { s -> s.seat }.map { seat ->
+        seat.seatType
+    }
 )
 
 fun List<Reservation>.toReservationAllResponseList(): List<ReservationAllResponse> = map {

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/dto/ReservationDetailByUserRequest.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/dto/ReservationDetailByUserRequest.kt
@@ -1,0 +1,8 @@
+package com.thepan.reservationapiserver.domain.reservation.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class ReservationDetailByUserRequest(
+    @field:NotBlank(message = "발급 받으신 예약 번호를 입력해주세요.")
+    val certificationNumber: String
+)

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/dto/ReservationDetailResponse.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/dto/ReservationDetailResponse.kt
@@ -1,0 +1,18 @@
+package com.thepan.reservationapiserver.domain.reservation.dto
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.thepan.reservationapiserver.domain.seat.entity.SeatType
+import java.time.LocalDateTime
+
+data class ReservationDetailResponse(
+    val id: Long?,
+    val name: String, // 성함
+    val phoneNumber: String, // 핸드폰 번호
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    val reservationDateTime: LocalDateTime, // 예약 시간
+    val reservationCount: Int, // 예약 인원 수
+    val isTermAllAgree: Boolean, // 약관 동의 여부
+    val isUserValidation: Boolean, // 본인 인증 여부
+    val certificationNumber: String?, // 예약 인증 번호
+    val seats: List<SeatType> // 예약한 좌석
+)

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/repository/ReservationRepository.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/reservation/repository/ReservationRepository.kt
@@ -1,6 +1,5 @@
 package com.thepan.reservationapiserver.domain.reservation.repository
 
-import com.thepan.reservationapiserver.domain.reservation.dto.ReservationAllResponse
 import com.thepan.reservationapiserver.domain.reservation.dto.ReservationClientCountResponseInterface
 import com.thepan.reservationapiserver.domain.reservation.entity.Reservation
 import com.thepan.reservationapiserver.domain.reservation.entity.ReservationSeat
@@ -17,6 +16,11 @@ interface ReservationRepository : JpaRepository<Reservation, Long>, CustomReserv
 
     @Query("SELECT r FROM Reservation r WHERE CAST(r.reservationDateTime AS date) = :date")
     fun findByReservationDate(date: LocalDate): List<Reservation>
+    
+    @Query("SELECT r FROM Reservation r WHERE r.certificationNumber = :certificationNumber")
+    fun findByCertificationNumber(
+        @Param("certificationNumber") certificationNumber: String
+    ): Reservation?
 
     // 📌 내 예약 정보를 가져옴
     @Query("SELECT r FROM Reservation r WHERE r.id = :reservationId AND r.timeType = :timeType AND r.reservationDateTime = :reservationDateTime")


### PR DESCRIPTION
## 🌸 예약 정보 상세보기
- `/reservation/{id}`
  > - 관리자, 마스터가 @PathValiable 로 넘어오는 `id` 를 통해 예약 상세정보를 가져올 경우 사용
  > - 인증 및 인가 적용

- `/reservation/user`
  > - 승인된 예약의 예약번호를 바탕으로 비인증 유저가 예약 상세정보를 가져올 경우 사용
  > - 인징 및 인가 둘다 적용하지 않음