### PR TITLE
🦋 Refresh Token 재발급 로직 추가 🦋

### DIFF
--- a/src/main/kotlin/com/thepan/reservationapiserver/advice/ExceptionAdvice.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/advice/ExceptionAdvice.kt
@@ -6,6 +6,7 @@ import mu.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.validation.BindException
+import org.springframework.web.bind.MissingRequestHeaderException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -146,5 +147,17 @@ class ExceptionAdvice {
     @ResponseStatus(HttpStatus.PAYLOAD_TOO_LARGE)
     fun multipartException(): ApiResponse<Unit> {
         return ApiResponse.failure(-1019, "파일 용량초과, 요청하신 파일이 너무 큽니다.")
+    }
+    
+    @ExceptionHandler(RefreshAuthenticationEntryPointException::class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    fun refreshAuthenticationEntryPointException(e: RefreshAuthenticationEntryPointException): ApiResponse<Unit> {
+        return ApiResponse.failure(-1020, e.message ?: "인증이 만료되었습니다. 다시 로그인해주세요.")
+    }
+    
+    @ExceptionHandler(MissingRequestHeaderException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun missingRequestHeaderException(e: MissingRequestHeaderException): ApiResponse<Unit> {
+        return ApiResponse.failure(-1021, "${e.headerName} 요청 헤더가 누락되었습니다.")
     }
 }

--- a/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/config/SecurityConfig.kt
@@ -46,6 +46,8 @@ class SecurityConfig(
             .authorizeHttpRequests { auth -> // 인증, 인가 설정
                 auth.requestMatchers(
                     "/api/v1/sign/signIn",
+                    "/api/v1/sign/signOut",
+                    "/api/v1/sign/refresh-token",
                     "/api/v1/sign/phone",
                     "/api/v1/sign/phone/check",
                     "/api/v1/seats/**",

--- a/src/main/kotlin/com/thepan/reservationapiserver/controller/ReservationApiController.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/controller/ReservationApiController.kt
@@ -90,7 +90,7 @@ class ReservationApiController(
         request: ReservationApprovalCheckRequest
     ): ApiResponse<Unit> {
         reservationService.updateAuthorizedReservation(id, request)
-        return ApiResponse.success()
+        return ApiResponse.success(successMsg = if (request.isApproved) "예약 승인 처리가 완료되었습니다." else "예약이 거절(삭제)되었습니다.")
     }
 
     @GetMapping("/reservation/non-auth/day-time")

--- a/src/main/kotlin/com/thepan/reservationapiserver/controller/SignApiController.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/controller/SignApiController.kt
@@ -23,9 +23,12 @@ class SignApiController(
     @PostMapping("/signOut")
     @ResponseStatus(HttpStatus.OK)
     fun signOut(
-        @RequestHeader(value = "Authorization") authorizationHeader: String
+        @RequestHeader(value = "Authorization") authorizationHeader: String,
+        @Valid
+        @RequestBody
+        request: SignOutRequest
     ): ApiResponse<Unit> {
-        signService.signOut(authorizationHeader)
+        signService.signOut(authorizationHeader, request)
         return ApiResponse.success()
     }
     

--- a/src/main/kotlin/com/thepan/reservationapiserver/controller/SignApiController.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/controller/SignApiController.kt
@@ -23,11 +23,17 @@ class SignApiController(
     @PostMapping("/signOut")
     @ResponseStatus(HttpStatus.OK)
     fun signOut(
-        @RequestHeader("Authorization") authorizationHeader: String
+        @RequestHeader(value = "Authorization") authorizationHeader: String
     ): ApiResponse<Unit> {
         signService.signOut(authorizationHeader)
         return ApiResponse.success()
     }
+    
+    @PostMapping("/refresh-token")
+    @ResponseStatus(HttpStatus.OK)
+    fun refreshToken(
+        @RequestHeader(value = "Authorization") refreshToken: String
+    ): ApiResponse<RefreshTokenResponse> = ApiResponse.success(signService.refreshToken(refreshToken))
     
     @PostMapping("/phone")
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/base/ApiResponse.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/base/ApiResponse.kt
@@ -11,10 +11,10 @@ data class ApiResponse<T>(
 ) {
     companion object {
         // 📌 응답은 성공했는데 반환할 데이터가 없는 경우
-        fun <T> success(): ApiResponse<T> = ApiResponse(true, resultMsg = "응답 성공", code = 200)
+        fun <T> success(successMsg: String? = null): ApiResponse<T> = ApiResponse(true, resultMsg = successMsg ?: "응답 성공", code = 200)
         
         // 📌 응답 성공, 데이터 포함
-        fun <T> success(data: T): ApiResponse<T> = ApiResponse(true, data, resultMsg = "응답 성공", code = 200)
+        fun <T> success(data: T, successMsg: String? = null): ApiResponse<T> = ApiResponse(true, data, resultMsg = successMsg ?: "응답 성공", code = 200)
         
         // 📌 응답 실패
         fun <T> failure(code: Int, resultMsg: String? = null): ApiResponse<T> =

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/dto/RefreshTokenResponse.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/dto/RefreshTokenResponse.kt
@@ -1,0 +1,5 @@
+package com.thepan.reservationapiserver.domain.sign.dto
+
+data class RefreshTokenResponse(
+    val accessToken: String
+)

--- a/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/dto/SignOutRequest.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/domain/sign/dto/SignOutRequest.kt
@@ -1,0 +1,10 @@
+package com.thepan.reservationapiserver.domain.sign.dto
+
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.PositiveOrZero
+
+data class SignOutRequest(
+    @field:NotNull
+    @field:PositiveOrZero(message = "올바른 memberId를 입력해주세요.")
+    val memberId: Long
+)

--- a/src/main/kotlin/com/thepan/reservationapiserver/exception/RefreshAuthenticationEntryPointException.kt
+++ b/src/main/kotlin/com/thepan/reservationapiserver/exception/RefreshAuthenticationEntryPointException.kt
@@ -1,0 +1,3 @@
+package com.thepan.reservationapiserver.exception
+
+class RefreshAuthenticationEntryPointException(message: String? = null) : RuntimeException(message)


### PR DESCRIPTION
## 🌸 Refresh Token 재발급
- API 👉 /sign/refresh-token
  > - RefreshToken 을 재발급 받는 코드 구현
  > - 인증 ❌, 인가 ❌ (애초에 accessToken 이 만료되었을때 사용되는 API 이므로 인증, 인가가 불가함)

- 로직 👇 
  ``` kotlin 
  @Transactional(readOnly = true) 
  fun refreshToken(refreshToken: String): RefreshTokenResponse { 
      if (!jwtTokenService.validateRefreshToken(refreshToken)) { 
          throw RefreshAuthenticationEntryPointException() 
      }

      val memberId = jwtTokenService.extractRefreshTokenSubject(refreshToken)
      val member = getFindByMemberId(memberId = memberId.toLong())

      // 이미 로그아웃 처리된 유저의 경우 refreshToken 을 사용하지 못하도록 수정
      if (redisTemplate.opsForValue()["RT:${member.email}"] == null) {
          throw RefreshAuthenticationEntryPointException("이미 로그아웃된 유저입니다. 다시 로그인해주세요.")
      }

      val accessToken = jwtTokenService.createAccessToken(memberId)
      return RefreshTokenResponse(accessToken = accessToken)
  }
  ```
  > - Header 에 Authorization 로 RefreshToken 을 받습니다. (이때 Header에 요청값이 없다면 MissingRequestHeaderException 이 발생합니다.)
  > - refreshToken 이 유효하지 않다면 RefreshAuthenticationEntryPointException 을 발생시킵니다.
  > - refreshToekn 이 유효하다면 해당 refreshToken 의 subject 를 추출합니다.
  > - 추출한 subject 로 member 를 조회하여 이미 로그아웃 API를 호출한 유저라면 RefreshAuthenticationEntryPointException 을 발생시킵니다.
  > - 모든 조건을 통과하면 해당 subject 를 바탕으로 새로운 AccessToken 을 만들고 반환합니다.